### PR TITLE
remove duplicate Gorgias loader and guard chat entrypoints

### DIFF
--- a/sections/header.liquid
+++ b/sections/header.liquid
@@ -38,7 +38,7 @@
                                   {% render 'icon-email', classes: 'w-6 h-6', aria_hidden: true %}
                                   <span>Email</span>
                                 </a>
-                                <button onclick="GorgiasChat.open()" class="button button-secondary button-sm button-icon button-icon-left w-full">
+                                <button onclick="if (window.GorgiasChat && typeof GorgiasChat.open === 'function') { GorgiasChat.open(); }" class="button button-secondary button-sm button-icon button-icon-left w-full">
                                   {% render 'icon-chat', classes: 'w-6 h-6', aria_hidden: true %}
                                   <span>Chat</span>
                                 </button>

--- a/snippets/gorgias-chat-widget.liquid
+++ b/snippets/gorgias-chat-widget.liquid
@@ -1,8 +1,4 @@
 {% comment %} Gorgias Chat Widget Start {% endcomment %}
-  {% comment %}theme-check-disable ParserBlockingJavaScript, RemoteAsset{% endcomment %}
-  <script id="gorgias-chat-widget-install-v3" src="https://config.gorgias.chat/bundle-loader/01GYCCDPGE0SBJA47915Z0YPJA"></script>
-  {% comment %}theme-check-enable ParserBlockingJavaScript, RemoteAsset{% endcomment %}
-
   <script type="text/lazyload">
     var initGorgiasChatPromise = window.GorgiasChat
       ? window.GorgiasChat.init()


### PR DESCRIPTION
**Problem**

PageSpeed showed Gorgias on the critical request chain, and storefront verification confirmed the widget loader was being requested twice:

- once from the Shopify/app-injected path
- once from the theme snippet
- The theme also had one visible chat entrypoint that called GorgiasChat.open() without checking that Gorgias had loaded.

**Solution**

- Removed the theme-owned Gorgias loader from gorgias-chat-widget.liquid
- Kept the lazy Gorgias customization logic intact so business hours and custom text still apply
- Updated the visible chat button in header.liquid to guard GorgiasChat.open() the same way as the existing sr-only trigger

**Validation**

- Confirmed only one config.gorgias.chat/bundle-loader/... script remains after the fix
- Confirmed gorgias-chat-bundle.js still loads
- Confirmed window.GorgiasChat is initialized and chat still works
- Ran shopify.cmd theme check; existing repo-wide issues remain, but no new issue was introduced by this change