### PR TITLE
Fix WCAG 2.5.3 Label in Name on homepage CTAs and customer tabs

### DIFF
--- a/templates/customers/login.liquid
+++ b/templates/customers/login.liquid
@@ -52,11 +52,11 @@
     </h1>
     <div>
       <div class="flex mb-6 gap-4 tracking-wide">
-        <a href="#" aria-label="You are on sign in tab" class="flex-1 button button-sm button-tertiary bg-wave-200 border-wave-200">
+        <a href="#" class="flex-1 button button-sm button-tertiary bg-wave-200 border-wave-200">
           {{ 'customer.login_page.sign_in' | t }}
         </a>
 
-        <a aria-label="Go to create account tab" href="{{ routes.account_register_url }}" class="flex-1 button button-sm button-white">
+        <a href="{{ routes.account_register_url }}" class="flex-1 button button-sm button-white">
           {{ 'customer.login_page.create_account' | t }}
         </a>
       </div>

--- a/templates/customers/register.liquid
+++ b/templates/customers/register.liquid
@@ -4,11 +4,11 @@
       {{- 'customer.register.title' | t -}}
     </h1>
     <div class="flex mb-6 gap-4 tracking-wide">
-      <a  href="{{ routes.account_login_url }}" aria-label="You are on sign in tab" class="flex-1 button button-sm button-white">
+      <a href="{{ routes.account_login_url }}" class="flex-1 button button-sm button-white">
         {{ 'customer.login_page.sign_in' | t }}
       </a>
 
-      <a aria-label="Go to create account tab" href="#" class="flex-1 button button-sm button-tertiary bg-wave-200 border-wave-200">
+      <a href="#" class="flex-1 button button-sm button-tertiary bg-wave-200 border-wave-200">
         {{ 'customer.login_page.create_account' | t }}
       </a>
     </div>

--- a/templates/index.json
+++ b/templates/index.json
@@ -28,7 +28,7 @@
             "remove_text_wrapper": false,
             "heading": "<h1 class=\"text-white font-serif text-5xl sm:text-4xl lg:text-6xl xl:text-7xl mb-4 sm:text-seaweed-700\">You <em>Have</em> to <br>Sea this Glow</h1>\n<p class=\"hidden sm:block mb-4 font-book sm:text-sm lg:text-lg xl:text-2xl xl:mb-6 2xl:px-10\">Seaweed-powered hyaluronic acid essentials deliver multi-level hydration for a glow that lasts.</p>",
             "heading_classes": "max-w-2xs md:max-w-xs lg:max-w-md xl:max-w-2xl xl:px-6",
-            "paragraph": "<a class=\"button button-primary px-3 xl:px-4\" href=\"/products/hyaluronic-body-serum\" aria-label=\"Shop Hyaluronic Body Serum\">Shop Body Serum</a>\n<a class=\"button button-primary px-3 xl:px-4\" href=\"/products/hyaluronic-sea-serum\" aria-label=\"Shop Hyaluronic Sea Serum\">Shop Face Serum</a>",
+            "paragraph": "<a class=\"button button-primary px-3 xl:px-4\" href=\"/products/hyaluronic-body-serum\" aria-label=\"Shop Body Serum - Hyaluronic Body Serum\">Shop Body Serum</a>\n<a class=\"button button-primary px-3 xl:px-4\" href=\"/products/hyaluronic-sea-serum\" aria-label=\"Shop Face Serum - Hyaluronic Sea Serum\">Shop Face Serum</a>",
             "paragraph_classes": "hidden sm:flex items-center justify-center gap-2 lg:gap-4 flex-col lg:flex-row",
             "button_label": "Shop Hydration",
             "button_aria_label": "Shop Hydration: The Hyaluronic Collection",


### PR DESCRIPTION
﻿Resolves SortSite "Visible label does not match accessible name" (WCAG 2.5.3, Level A). Theme code only — no JS, apps, or Shopify-generated markup.

**Changes (3 files, 5 lines):**
- `index.json` — CTA aria-labels now lead with the visible text: "Shop Body Serum - …", "Shop Face Serum - …"
- `customers/login.liquid` + `register.liquid` — removed hardcoded "tab" aria-labels; accessible name now comes from the localized visible text

**Validation:** `npm run build` clean · `shopify theme check` 0 offenses on edited files · no regressions.

**Before merge to Main:** SortSite rescan of Sandbox to confirm the finding count drops.
