### PR TITLE
Fix WCAG 2.5.3 on Add-to-bag buttons (price not in accessible name)

### DIFF
--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -377,7 +377,7 @@
                 <span class="label">
                   {{ 'products.product.add_to_cart' | t }}
                 </span>
-                {%- render 'price', product: product, use_variant: true, price_class: 'main-price ml-auto' -%}
+                {%- render 'price', product: product, use_variant: true, price_class: 'main-price ml-auto', in_button: true -%}
               </button>
             </div>
             <div

--- a/snippets/card-product.liquid
+++ b/snippets/card-product.liquid
@@ -349,7 +349,8 @@
                     subscription: subscription,
                     default_to_mini: default_to_mini,
                     default_to_jumbo: default_to_jumbo,
-                    hide_slashed_price: hide_slashed_price
+                    hide_slashed_price: hide_slashed_price,
+                    in_button: true
                   -%}
                 {%- endunless -%}
               </button>

--- a/snippets/component-button.liquid
+++ b/snippets/component-button.liquid
@@ -84,7 +84,8 @@
         product: product,
         use_variant: use_variant,
         price_class: price_class,
-        slashed_price_color: slashed_price_color
+        slashed_price_color: slashed_price_color,
+        in_button: true
       -%}
     {%- endif -%}
   {%- if element == 'a' -%}

--- a/snippets/price.liquid
+++ b/snippets/price.liquid
@@ -12,6 +12,7 @@
   - default_to_mini: {Boolean} Default variant selection to smallest size (optional)
   - default_to_jumbo: {Boolean} Default variant selection to largest size (optional)
   - hide_slashed_price: {Boolean} Hides slashed price (optional)
+  - in_button: {Boolean} When the price is rendered inside a button or link, exposes the visible price to the accessibility tree and omits the SR-only label, so the control's accessible name matches its visible label (WCAG 2.5.3). Leave unset for standalone prices (optional)
   - slashed_price_color: {120px} Color of the slashed price (optional)
 
   Usage:
@@ -93,11 +94,11 @@
   class="price whitespace-nowrap flex flex-row{% if price_class %} {{ price_class }}{% endif %}"
   {% if price_id != blank %}id="{{ price_id }}"{% endif %}
 >
-  {%- if sr_text != blank -%}
+  {%- if sr_text != blank and in_button != true -%}
     <span class="sr-only">{{ sr_text }}</span>
   {%- endif -%}
 
-  <span aria-hidden="true" class="flex flex-row">
+  <span {% unless in_button %}aria-hidden="true" {% endunless %}class="flex flex-row">
     {%- if subscription -%}
       {%- if product.selected_or_first_available_variant.available -%}
         <s class="{{ slashed_price_color }} font-medium mr-1">

--- a/snippets/product-upsell.liquid
+++ b/snippets/product-upsell.liquid
@@ -49,6 +49,7 @@
                   product: product,
                   show_price_range: false,
                   use_variant: true,
+                  in_button: true
                 %}
               </span>
             {%- endunless -%}


### PR DESCRIPTION
﻿Resolves the SortSite "The visual label must appear in the accessible name of links and controls" finding (WCAG 2.5.3 / F96, ~46 pages).

**Root cause:** inside an "Add to bag" button, `snippets/price.liquid` renders an SR-only label ("Price, $58.", "Original price… Sale price…", "Price range, $X to $Y.") and `aria-hidden`s the visible price. Correct for a standalone price, but inside a control it makes the button's accessible name ("Add to bag Price, $58.") not contain its visible label ("Add to bag $58") — failing F96. Rides every product card → ~46 pages.

**Fix:** add an `in_button` flag to `price.liquid`. When set, it omits the SR-only label and exposes the visible price to the accessibility tree, so the control's accessible name equals its visible text — for simple, sale, and price-range formats alike (the name is derived from the same visible nodes, so it cannot mismatch).

Passed `in_button: true` from the controls that embed a price:
- `snippets/card-product.liquid` — product-card ATC (confirmed 46-page source)
- `snippets/component-button.liquid` — reusable button/link with price
- `snippets/product-upsell.liquid` — upsell ATC
- `sections/main-product.liquid` — PDP main ATC

**Not touched:** `sections/multicolumn.liquid` ATC uses `aria-labelledby` (different name computation) — left for separate review.

**Impact:** no visual or functional change. Standalone prices keep their full SR phrasing.

**Trade-off (intentional, option A):** inside these buttons the descriptive sale/range phrasing is dropped in favor of matching the visible label.

**Validation:** `npm run build` clean; `shopify theme check` 0 offenses on all 5 files. Live confirmation pending Sandbox theme pull + rescan (expected 46 to 0, minus any straggler such as the multicolumn ATC).
