### PR TITLE
Fix WCAG 2.5.3 on multicolumn ATC (final F96 page)

### DIFF
--- a/sections/multicolumn.liquid
+++ b/sections/multicolumn.liquid
@@ -356,7 +356,6 @@
                                 type="submit"
                                 name="add"
                                 aria-haspopup="dialog"
-                                aria-labelledby="{{ product_form_id }}-submit title-{{ block.id }}-{{ block.settings.atc_button_product.id }}"
                                 aria-live="polite"
                                 class="button w-full transition flex mt-2 disabled:opacity-50 {% if block.settings.atc_button_product.selected_or_first_available_variant.available %}justify-between{% else %}justify-center{% endif %} {{ block.settings.button_classes }}"
                                 {% if block.settings.atc_button_product.selected_or_first_available_variant.available == false %}disabled{% endif %}
@@ -373,7 +372,8 @@
                                         product: block.settings.atc_button_product,
                                         show_price_range: block.settings.show_variants and block.settings.atc_button_product.has_only_default_variant == false,
                                         use_variant: true,
-                                        subscription: block.settings.is_subscription
+                                        subscription: block.settings.is_subscription,
+                                        in_button: true
                                       %}
                                     </span>
                                   {%- endunless -%}


### PR DESCRIPTION
﻿Clears the final SortSite F96 page (WCAG 2.5.3) on /pages/clinical-results-body-moisturizers.

**Root cause:** the multicolumn Add-to-bag button used `aria-labelledby="{form}-submit title-{block}-{product}"`. That `title-…` id exists nowhere in the theme, and the self-reference pulled in the price snippet's SR-only phrasing — producing a name like `Add to bag Price, $56. $56` (duplicated price), so the visible label `Add to bag $56` was not contained in it.

`aria-labelledby` is also fundamentally incompatible with F96 here: the visible label is `Add to bag $56`, so the accessible name must contain that contiguously — any inserted text breaks it.

**Fix (`sections/multicolumn.liquid`):**
- Remove the broken `aria-labelledby` so the button name computes naturally from its subtree.
- Pass `in_button: true` to the price render so the visible price (not the SR-only label) is in the name.

Result: accessible name == visible label (`Add to bag $56`, `Add to bag $16 - $84`, etc.). No visual or functional change.

**Minor trade-off:** without `aria-labelledby`, two products with identical prices on the same page would share the button name `Add to bag $X` (distinguished by surrounding context). The previous attempt at per-product naming was broken and F96-incompatible anyway.

**Validation:** `npm run build` clean; `shopify theme check` 0 offenses on the file. Expected SortSite: visual-label 1 → 0 (issue clears entirely) after Sandbox theme pull + rescan.
