### PR TITLE
Accessibility: Add-to-bag price-label fix (WCAG 2.5.3) [conversion-critical]

### DIFF
--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -377,7 +377,7 @@
                 <span class="label">
                   {{ 'products.product.add_to_cart' | t }}
                 </span>
-                {%- render 'price', product: product, use_variant: true, price_class: 'main-price ml-auto' -%}
+                {%- render 'price', product: product, use_variant: true, price_class: 'main-price ml-auto', in_button: true -%}
               </button>
             </div>
             <div

--- a/sections/multicolumn.liquid
+++ b/sections/multicolumn.liquid
@@ -356,7 +356,6 @@
                                 type="submit"
                                 name="add"
                                 aria-haspopup="dialog"
-                                aria-labelledby="{{ product_form_id }}-submit title-{{ block.id }}-{{ block.settings.atc_button_product.id }}"
                                 aria-live="polite"
                                 class="button w-full transition flex mt-2 disabled:opacity-50 {% if block.settings.atc_button_product.selected_or_first_available_variant.available %}justify-between{% else %}justify-center{% endif %} {{ block.settings.button_classes }}"
                                 {% if block.settings.atc_button_product.selected_or_first_available_variant.available == false %}disabled{% endif %}
@@ -373,7 +372,8 @@
                                         product: block.settings.atc_button_product,
                                         show_price_range: block.settings.show_variants and block.settings.atc_button_product.has_only_default_variant == false,
                                         use_variant: true,
-                                        subscription: block.settings.is_subscription
+                                        subscription: block.settings.is_subscription,
+                                        in_button: true
                                       %}
                                     </span>
                                   {%- endunless -%}

--- a/snippets/card-product.liquid
+++ b/snippets/card-product.liquid
@@ -349,7 +349,8 @@
                     subscription: subscription,
                     default_to_mini: default_to_mini,
                     default_to_jumbo: default_to_jumbo,
-                    hide_slashed_price: hide_slashed_price
+                    hide_slashed_price: hide_slashed_price,
+                    in_button: true
                   -%}
                 {%- endunless -%}
               </button>

--- a/snippets/component-button.liquid
+++ b/snippets/component-button.liquid
@@ -84,7 +84,8 @@
         product: product,
         use_variant: use_variant,
         price_class: price_class,
-        slashed_price_color: slashed_price_color
+        slashed_price_color: slashed_price_color,
+        in_button: true
       -%}
     {%- endif -%}
   {%- if element == 'a' -%}

--- a/snippets/price.liquid
+++ b/snippets/price.liquid
@@ -12,6 +12,7 @@
   - default_to_mini: {Boolean} Default variant selection to smallest size (optional)
   - default_to_jumbo: {Boolean} Default variant selection to largest size (optional)
   - hide_slashed_price: {Boolean} Hides slashed price (optional)
+  - in_button: {Boolean} When the price is rendered inside a button or link, exposes the visible price to the accessibility tree and omits the SR-only label, so the control's accessible name matches its visible label (WCAG 2.5.3). Leave unset for standalone prices (optional)
   - slashed_price_color: {120px} Color of the slashed price (optional)
 
   Usage:
@@ -93,11 +94,11 @@
   class="price whitespace-nowrap flex flex-row{% if price_class %} {{ price_class }}{% endif %}"
   {% if price_id != blank %}id="{{ price_id }}"{% endif %}
 >
-  {%- if sr_text != blank -%}
+  {%- if sr_text != blank and in_button != true -%}
     <span class="sr-only">{{ sr_text }}</span>
   {%- endif -%}
 
-  <span aria-hidden="true" class="flex flex-row">
+  <span {% unless in_button %}aria-hidden="true" {% endunless %}class="flex flex-row">
     {%- if subscription -%}
       {%- if product.selected_or_first_available_variant.available -%}
         <s class="{{ slashed_price_color }} font-medium mr-1">

--- a/snippets/product-upsell.liquid
+++ b/snippets/product-upsell.liquid
@@ -49,6 +49,7 @@
                   product: product,
                   show_price_range: false,
                   use_variant: true,
+                  in_button: true
                 %}
               </span>
             {%- endunless -%}


### PR DESCRIPTION
﻿Promotes the validated Add-to-bag price-label accessibility fix from `sandbox` to `main` (production). Cherry-picked, not merged from sandbox.

**Fix (WCAG 2.5.3 / F96 — "visual label must appear in the accessible name"):** inside an Add-to-bag button, the price snippet's SR-only label ("Price, $56.", "Original price… Sale price…", "Price range, $X to $Y.") became part of the button's accessible name while the visible price was `aria-hidden`, so the visible label ("Add to bag $56") was not contained in the name. Affected ~46 pages (every product card).

Adds an `in_button` flag to `snippets/price.liquid` that, inside a control, omits the SR-only label and exposes the visible price to the accessibility tree so the button name == its visible label. Passed from the card ATC, component-button, product-upsell, and PDP main ATC. The multicolumn ATC commit additionally removes a broken `aria-labelledby` and uses the same flag.

**Files:** `price.liquid`, `card-product.liquid`, `component-button.liquid`, `product-upsell.liquid`, `main-product.liquid`, `multicolumn.liquid`.

**Risk:** higher — this touches the shared price snippet and conversion-critical Add-to-bag buttons. **No visual or functional change** (only non-rendering a11y attributes/sr-only spans change); verified on the live sandbox page that visible button text was byte-identical before/after. Validated on `sandbox` — SortSite F96 went from 46 pages to 0.

**Validation here:** `npm run build` clean, `shopify theme check` 0 offenses on all 6 files, diff limited to those files.

**Recommend before merge:** preview-theme test that Add-to-bag still renders and submits on a product + collection page. Merging deploys to production; `main2`/`main3` will need a sync afterward.
