### PR TITLE
Fix WCAG ARIA naming on featured-review star SVG (SortSite Level A)

### DIFF
--- a/sections/product-clinicals.liquid
+++ b/sections/product-clinicals.liquid
@@ -41,7 +41,7 @@
       {%- if product.metafields.custom.featured_review != blank -%}
       <div class="text-center bg-p-surface text-p-inverse-d3 rounded-xl p-4 lg:p-6 xl:px-8 xl:py-10">
         <h3 class="sr-only">Featured Review</h3>
-        <svg aria-label="5 stars" xmlns="http://www.w3.org/2000/svg" width="116" height="20" viewbox="0 0 116 20" fill="{{ product.metafields.theme.inverse | default: '#1d4d41' }}" class="mx-auto mb-3 text-p-inverse">
+        <svg role="img" aria-label="5 stars" xmlns="http://www.w3.org/2000/svg" width="116" height="20" viewBox="0 0 116 20" fill="{{ product.metafields.theme.inverse | default: '#1d4d41' }}" class="mx-auto mb-3 text-p-inverse">
           <polygon points="13.09 6.26 20 7.27 15 12.14 16.18 19.02 10 15.77 3.82 19.02 5 12.14 0 7.27 6.91 6.26 10 0"></polygon>
           <polygon points="37.09 6.26 44 7.27 39 12.14 40.18 19.02 34 15.77 27.82 19.02 29 12.14 24 7.27 30.91 6.26 34 0"></polygon>
           <polygon points="61.09 6.26 68 7.27 63 12.14 64.18 19.02 58 15.77 51.82 19.02 53 12.14 48 7.27 54.91 6.26 58 0"></polygon>


### PR DESCRIPTION
Fixes the SortSite Level A finding **"Cannot use aria-label/aria-labelledby/aria-braillelabel on elements and roles that prohibit naming"** (7 product pages).

**Root cause:** the featured-review 5-star `<svg>` in `sections/product-clinicals.liquid` carried `aria-label="5 stars"` but no `role`. An `<svg>` with no explicit role has an implicit *generic* role, which prohibits naming — so the label was invalid and the rating was not exposed to assistive tech.

**Fix:** add `role="img"` so the element is namable and the label is valid (screen readers announce "5 stars"). Also corrected the ignored lowercase `viewbox` → `viewBox` on the same element.

**No visual change:** the viewBox dimensions (`0 0 116 20`) equal the SVG `width`/`height` (116×20) and the 5 polygons span exactly that space, so the mapping is 1:1 — rendering is byte-identical before/after.

**Files:** `sections/product-clinicals.liquid` (1 line).

**Validation:** `shopify theme check` — 0 offenses on the changed file (pre-existing offenses elsewhere untouched); diff limited to the one line.

**Affected pages (from SortSite sandbox scan):** anti-aging-body-balm, hyaluronic-sea-serum, marine-screen-spf-50-mineral-sunscreen, undaria-algae-oil, + 3 more PDPs with a featured-review block.

Merging to `sandbox` lets us re-run SortSite to confirm 7 → 0 before cutting a promotion PR to `main`.