### PR TITLE
Give promo image links an accessible name (SortSite F89)

### DIFF
--- a/sections/main-collection.liquid
+++ b/sections/main-collection.liquid
@@ -76,7 +76,8 @@
                 {%- render 'collection-promo-tile',
                   promo_tile_image: promo_tile_image,
                   promo_tile_video: promo_tile_video,
-                  promo_tile_url: promo_tile_url
+                  promo_tile_url: promo_tile_url,
+                  promo_tile_title: collection.title
                 -%}
               </li>
             {%- endif -%}
@@ -91,7 +92,8 @@
                     promo_section_content_classes: interrupter.content_classes,
                     promo_section_url: interrupter.url,
                     promo_section_image_wrapper_classes: interrupter.image_wrapper_classes,
-                    promo_section_link_classes: interrupter.link_classes
+                    promo_section_link_classes: interrupter.link_classes,
+                    promo_section_title: collection.title
                   %}
                 </li>
               {%- endfor -%}

--- a/sections/multicolumn.liquid
+++ b/sections/multicolumn.liquid
@@ -67,7 +67,7 @@
                 {%- when 'column' -%}
                   {%- if block.settings.image != blank and block.settings.is_bg_image == false -%}
                     {%- if block.settings.image_link != blank -%}
-                      <a href="{{ block.settings.image_link }}"{% if block.settings.image_link_classes != blank %} class="{{ block.settings.image_link_classes }}"{% endif %}>
+                      <a href="{{ block.settings.image_link }}"{% if block.settings.image_link_classes != blank %} class="{{ block.settings.image_link_classes }}"{% endif %}{% if block.settings.image.alt == blank and block.settings.heading != blank %} aria-label="{{ block.settings.heading | strip_html | escape }}"{% endif %}>
                     {%- endif -%}
 
                     {% comment %}theme-check-disable RemoteAsset {% endcomment %}

--- a/snippets/collection-promo-section.liquid
+++ b/snippets/collection-promo-section.liquid
@@ -15,6 +15,13 @@
   assign mobile_master = mobile_img | image_url
   assign desktop_master = desktop_img | image_url
 
+  # Accessible-name fallback: the link's name comes from the image alt; when blank
+  # (or for the video variant) fall back to a passed-in title so the link isn't nameless.
+  assign promo_section_alt = desktop_img.alt
+  if mobile_img != blank
+    assign promo_section_alt = mobile_img.alt
+  endif
+
   # The collection interrupter sits inside the padded page container on mobile.
   assign promo_sizes = promo_section_sizes | default: '(min-width: 400px) calc(100vw - 3rem), calc(100vw - 2rem)'
 
@@ -39,7 +46,7 @@
 -%}
 
 {%- if promo_section_url != blank -%}
-  <a href="{{ promo_section_url }}" class="block {{ promo_section_link_classes }}">
+  <a href="{{ promo_section_url }}" class="block {{ promo_section_link_classes }}"{% if promo_section_alt == blank and promo_section_title != blank %} aria-label="{{ promo_section_title | escape }}"{% endif %}>
 {%- endif -%}
 
 {% if has_video %}

--- a/snippets/collection-promo-tile.liquid
+++ b/snippets/collection-promo-tile.liquid
@@ -3,6 +3,7 @@
   - promo_tile_image: {ImageDrop} Liquid image object
   - promo_tile_url: {String} Link to promo tile destination (optional)
   - promo_tile_video: {VideoDrop} Liquid video object (optional)
+  - promo_tile_title: {String} Fallback link label used when the image has no alt text (optional)
 
   Usage:
   {% render 'collection-promo-tile', promo_tile_image: collection.metafields.image.url %}
@@ -14,7 +15,7 @@
     assign promo_tile_sizes = '(min-width: 1024px) calc((100vw - 6rem) / 4), (min-width: 768px) calc((100vw - 5rem) / 3), (min-width: 640px) calc((100vw - 4rem) / 2), (min-width: 400px) calc((100vw - 3.5rem) / 2), calc((100vw - 2.5rem) / 2)'
   -%}
   {%- if promo_tile_url != blank -%}
-    <a href="{{ promo_tile_url }}" class="block absolute inset-0 plp-tile-clickarea">
+    <a href="{{ promo_tile_url }}" class="block absolute inset-0 plp-tile-clickarea"{% if promo_tile_image.alt == blank and promo_tile_title != blank %} aria-label="{{ promo_tile_title | escape }}"{% endif %}>
   {%- else -%}
     <div>
   {%- endif -%}


### PR DESCRIPTION
Fixes the SortSite Level A finding **"Links must have an accessible name"** (~10 pages).

**Plain version:** Some promo images that link somewhere (the homepage multicolumn image link, and the clickable promo tiles/interrupters on collection pages) get their screen-reader name from the image's alt text. When a merchant leaves alt text blank in Shopify, the link has nothing to announce, so it fails.

**Fix:** add a conditional `aria-label` that only kicks in when the image alt is empty, falling back to a meaningful name:
- `collection-promo-tile` + `collection-promo-section` → the **collection title** (passed in from `main-collection`).
- `multicolumn` column image link → the column's own **heading** text.

Real alt text still wins when it's set, so nothing changes for images that already have alt. **No visual or functional change** — only an attribute is added, and only when it was missing.

**Files:** `snippets/collection-promo-tile.liquid`, `snippets/collection-promo-section.liquid`, `sections/multicolumn.liquid`, `sections/main-collection.liquid`.

**Validation:** `shopify theme check` — 0 offenses on the 4 changed files (44 pre-existing offenses elsewhere untouched).

**Note on the homepage hit:** the multicolumn fallback uses the column's heading. If that one homepage column has no heading *and* no alt text, it won't auto-clear — in that case the quickest fix is to add alt text to that image in Shopify. Worth confirming on the re-scan.

Merging to `sandbox` lets us re-run SortSite to confirm the count drops before promoting to `main`.