### PR TITLE
Clear remaining nameless links: rating jump-link + empty buttons (Sor…

### DIFF
--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -89,7 +89,7 @@
             {%- when 'rating' -%}
               <div class="{{ block.settings.rating_classes }} flex gap-2 items-center">
                 {%- unless excluded_from_site -%}
-                  <a href="#reviews">
+                  <a href="#reviews" aria-label="Read reviews">
                     {% render 'product-rating', product: product %}
                   </a>
                 {%- endunless -%}

--- a/sections/multicolumn.liquid
+++ b/sections/multicolumn.liquid
@@ -385,6 +385,7 @@
                           </product-form>
                         </div>
                       {%- else -%}
+                        {%- if block.settings.button_label != blank or block.settings.button_icon != blank -%}
                         <a
                           class="button {{ block.settings.button_classes }}"
                           {% if block.settings.link == blank %}role="link" aria-disabled="true"
@@ -397,6 +398,7 @@
                             {{- block.settings.button_icon -}}
                           {%- endif -%}
                         </a>
+                        {%- endif -%}
                       {%- endif -%}
                     {%- endif -%}
 

--- a/sections/rich-text.liquid
+++ b/sections/rich-text.liquid
@@ -26,6 +26,7 @@
         {%- when 'paragraph' -%}
           <div class="{{ block.settings.paragraph_classes }}" {{ block.shopify_attributes }}>{{ block.settings.paragraph_text }}</div>
         {%- when 'button' -%}
+          {%- if block.settings.button_label != blank or block.settings.button_icon != blank -%}
           <a
             {% if block.settings.button_link == blank %}role="link" aria-disabled="true"
             {% else %}href="{{ block.settings.button_link }}"{% endif %}
@@ -40,6 +41,7 @@
               {{- block.settings.button_icon -}}
             {%- endif -%}
           </a>
+          {%- endif -%}
         {%- when 'image' -%}
           {%- if block.settings.image_mobile != blank -%}
             {%- if block.settings.image_link != blank -%}


### PR DESCRIPTION
…tSite F89)

Two leftovers after the promo-image fix:
- main-product rating block: the "#reviews" jump link wraps only the Okendo star snippet (image, no text), so the link had no accessible name. Add aria-label="Read reviews" (Okendo snippet left untouched).
- rich-text and multicolumn button blocks rendered an empty, disabled <a role="link" aria-disabled="true"> when both label and icon were blank — a nameless link. Guard them to render only when a label or icon is present, matching image-banner / page-banner.

No visual or functional change for buttons that have content.