### PR TITLE
Fix F96 regression on product rating link (sr-only label)

### DIFF
--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -89,7 +89,8 @@
             {%- when 'rating' -%}
               <div class="{{ block.settings.rating_classes }} flex gap-2 items-center">
                 {%- unless excluded_from_site -%}
-                  <a href="#reviews" aria-label="Read reviews">
+                  <a href="#reviews">
+                    <span class="sr-only">Read reviews</span>
                     {% render 'product-rating', product: product %}
                   </a>
                 {%- endunless -%}


### PR DESCRIPTION
Fixes a WCAG 2.5.3 / F96 ("visual label must appear in the accessible name") regression I introduced in the F89 link-name work (PR #107), now ~13 pages.

**What went wrong:** the F89 fix added `aria-label="Read reviews"` to the product rating jump-link (`<a href="#reviews">`). On products that have reviews, Okendo renders a visible count like "825 Reviews" — and the aria-label *overrode* that as the link's accessible name. So the visible label ("825 Reviews") was no longer contained in the name ("Read reviews") → F96 fail. SortSite confirmed: *Label "825 Reviews" not in name "Read reviews"*.

**Fix:** replace the aria-label with a visually-hidden `<span class="sr-only">Read reviews</span>` inside the link. A hidden span is *appended* to the accessible name rather than replacing it:
- **With reviews:** name = "825 Reviews Read reviews" → visible label is contained → passes F96, still named → passes F89.
- **Without reviews** (e.g. undaria-body-butter): name = "Read reviews" → link still has a name → passes F89.

Okendo's star snippet is untouched. No visual change.

**File:** `sections/main-product.liquid` (1 line).

**Validation:** `shopify theme check` — 0 offenses on the file (44 pre-existing elsewhere untouched).

After merge to `sandbox`, re-scan should drop F96 back (these ~13 rating-link instances clear) and F89 stays at 0.