### PR TITLE
Show first-time GWP on the product page

### DIFF
--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -114,17 +114,32 @@
                 else
                   assign free_gifts_active = false
                 endif
+
+                # First-time GWP — never shown while the tiered GWP is enabled; otherwise mirror cart drawer gate (guests + first-time buyers only)
+                assign firsttime_gift_active = false
+                unless settings.enable_gwp
+                  if settings.enable_firstime_gwp and settings.gwp_firsttime_product != blank
+                    unless customer and customer.orders_count > 0
+                      assign firsttime_gift_active = true
+                    endunless
+                  endif
+                endunless
               -%}
-              {%- if free_gifts_active -%}
+              {%- if free_gifts_active or firsttime_gift_active -%}
                 <div class="{{ block.settings.free_gift_info_classes }}">
-                  {%- if settings.gwp_tier1_product != blank -%}
-                    {% render 'product-free-gift-info', product: settings.gwp_tier1_product, threshold: settings.gwp_tier1_threshold %}
+                  {%- if free_gifts_active -%}
+                    {%- if settings.gwp_tier1_product != blank -%}
+                      {% render 'product-free-gift-info', product: settings.gwp_tier1_product, threshold: settings.gwp_tier1_threshold %}
+                    {%- endif -%}
+                    {%- if settings.gwp_tier2_product != blank -%}
+                      {% render 'product-free-gift-info', product: settings.gwp_tier2_product, threshold: settings.gwp_tier2_threshold %}
+                    {%- endif -%}
+                    {%- if settings.gwp_tier3_product != blank -%}
+                      {% render 'product-free-gift-info', product: settings.gwp_tier3_product, threshold: settings.gwp_tier3_threshold %}
+                    {%- endif -%}
                   {%- endif -%}
-                  {%- if settings.gwp_tier2_product != blank -%}
-                    {% render 'product-free-gift-info', product: settings.gwp_tier2_product, threshold: settings.gwp_tier2_threshold %}
-                  {%- endif -%}
-                  {%- if settings.gwp_tier3_product != blank -%}
-                    {% render 'product-free-gift-info', product: settings.gwp_tier3_product, threshold: settings.gwp_tier3_threshold %}
+                  {%- if firsttime_gift_active -%}
+                    {% render 'product-free-gift-info', product: settings.gwp_firsttime_product, first_time: true %}
                   {%- endif -%}
                 </div>
               {%- endif -%}

--- a/snippets/product-free-gift-info.liquid
+++ b/snippets/product-free-gift-info.liquid
@@ -7,9 +7,11 @@
     assign gift_image_src_2x = product.featured_image | image_url: width: 252
   endif
 
-  assign threshold_total = threshold | times: 100
+  unless first_time
+    assign threshold_total = threshold | times: 100
+  endunless
 -%}
-{%- unless cart.total_price >= threshold_total -%}
+{%- if first_time or cart.total_price < threshold_total -%}
 <div class="w-full bg-wave-200 rounded-lg px-2 py-1 my-2">
   <div class="flex items-center gap-2">
     {% comment %} theme-check-disable RemoteAsset {% endcomment %}
@@ -24,9 +26,14 @@
     >
     {% comment %} theme-check-enable RemoteAsset {% endcomment %}
     <div class="flex flex-col">
-      <p class="text-sm font-bold uppercase tracking-wider">Free Gift with orders {{ threshold | times: 100 | money_without_trailing_zeros }}+</p>
-      <p class="text-sm leading-tight">Spend {{ threshold_total | minus: cart.total_price | money_without_trailing_zeros }} to claim your {{ product.title | replace: 'Free Gift - ', '' }}!</p>
+      {%- if first_time -%}
+        <p class="text-sm font-bold uppercase tracking-wider">Free Gift with your first order</p>
+        <p class="text-sm leading-tight">Claim your {{ product.title | replace: 'Free Gift - ', '' }} on your first order!</p>
+      {%- else -%}
+        <p class="text-sm font-bold uppercase tracking-wider">Free Gift with orders {{ threshold | times: 100 | money_without_trailing_zeros }}+</p>
+        <p class="text-sm leading-tight">Spend {{ threshold_total | minus: cart.total_price | money_without_trailing_zeros }} to claim your {{ product.title | replace: 'Free Gift - ', '' }}!</p>
+      {%- endif -%}
     </div>
   </div>
 </div>
-{%- endunless -%}
+{%- endif -%}


### PR DESCRIPTION
Render the first-time gift-with-purchase in the product page free_gift_info block, reusing product-free-gift-info.liquid via a new first_time mode. Shown to guests/first-time buyers only, and only when the tiered GWP (enable_gwp) is off.