### PR TITLE
Accessibility: accessible names for promo image links + clinical star SVG

### DIFF
--- a/sections/main-collection.liquid
+++ b/sections/main-collection.liquid
@@ -76,7 +76,8 @@
                 {%- render 'collection-promo-tile',
                   promo_tile_image: promo_tile_image,
                   promo_tile_video: promo_tile_video,
-                  promo_tile_url: promo_tile_url
+                  promo_tile_url: promo_tile_url,
+                  promo_tile_title: collection.title
                 -%}
               </li>
             {%- endif -%}
@@ -91,7 +92,8 @@
                     promo_section_content_classes: interrupter.content_classes,
                     promo_section_url: interrupter.url,
                     promo_section_image_wrapper_classes: interrupter.image_wrapper_classes,
-                    promo_section_link_classes: interrupter.link_classes
+                    promo_section_link_classes: interrupter.link_classes,
+                    promo_section_title: collection.title
                   %}
                 </li>
               {%- endfor -%}

--- a/sections/main-collection.liquid
+++ b/sections/main-collection.liquid
@@ -93,7 +93,8 @@
                     promo_section_url: interrupter.url,
                     promo_section_image_wrapper_classes: interrupter.image_wrapper_classes,
                     promo_section_link_classes: interrupter.link_classes,
-                    promo_section_title: collection.title
+                    promo_section_alt_text: interrupter.image_alt_text.value,
+                    promo_section_title: interrupter.collection.value | default: collection.title
                   %}
                 </li>
               {%- endfor -%}

--- a/sections/multicolumn.liquid
+++ b/sections/multicolumn.liquid
@@ -67,7 +67,7 @@
                 {%- when 'column' -%}
                   {%- if block.settings.image != blank and block.settings.is_bg_image == false -%}
                     {%- if block.settings.image_link != blank -%}
-                      <a href="{{ block.settings.image_link }}"{% if block.settings.image_link_classes != blank %} class="{{ block.settings.image_link_classes }}"{% endif %}>
+                      <a href="{{ block.settings.image_link }}"{% if block.settings.image_link_classes != blank %} class="{{ block.settings.image_link_classes }}"{% endif %}{% if block.settings.image.alt == blank and block.settings.heading != blank %} aria-label="{{ block.settings.heading | strip_html | escape }}"{% endif %}>
                     {%- endif -%}
 
                     {% comment %}theme-check-disable RemoteAsset {% endcomment %}

--- a/sections/product-clinicals.liquid
+++ b/sections/product-clinicals.liquid
@@ -41,7 +41,7 @@
       {%- if product.metafields.custom.featured_review != blank -%}
       <div class="text-center bg-p-surface text-p-inverse-d3 rounded-xl p-4 lg:p-6 xl:px-8 xl:py-10">
         <h3 class="sr-only">Featured Review</h3>
-        <svg aria-label="5 stars" xmlns="http://www.w3.org/2000/svg" width="116" height="20" viewbox="0 0 116 20" fill="{{ product.metafields.theme.inverse | default: '#1d4d41' }}" class="mx-auto mb-3 text-p-inverse">
+        <svg role="img" aria-label="5 stars" xmlns="http://www.w3.org/2000/svg" width="116" height="20" viewBox="0 0 116 20" fill="{{ product.metafields.theme.inverse | default: '#1d4d41' }}" class="mx-auto mb-3 text-p-inverse">
           <polygon points="13.09 6.26 20 7.27 15 12.14 16.18 19.02 10 15.77 3.82 19.02 5 12.14 0 7.27 6.91 6.26 10 0"></polygon>
           <polygon points="37.09 6.26 44 7.27 39 12.14 40.18 19.02 34 15.77 27.82 19.02 29 12.14 24 7.27 30.91 6.26 34 0"></polygon>
           <polygon points="61.09 6.26 68 7.27 63 12.14 64.18 19.02 58 15.77 51.82 19.02 53 12.14 48 7.27 54.91 6.26 58 0"></polygon>

--- a/snippets/collection-promo-section.liquid
+++ b/snippets/collection-promo-section.liquid
@@ -15,6 +15,13 @@
   assign mobile_master = mobile_img | image_url
   assign desktop_master = desktop_img | image_url
 
+  # Accessible-name fallback: the link's name comes from the image alt; when blank
+  # (or for the video variant) fall back to a passed-in title so the link isn't nameless.
+  assign promo_section_alt = desktop_img.alt
+  if mobile_img != blank
+    assign promo_section_alt = mobile_img.alt
+  endif
+
   # The collection interrupter sits inside the padded page container on mobile.
   assign promo_sizes = promo_section_sizes | default: '(min-width: 400px) calc(100vw - 3rem), calc(100vw - 2rem)'
 
@@ -39,7 +46,7 @@
 -%}
 
 {%- if promo_section_url != blank -%}
-  <a href="{{ promo_section_url }}" class="block {{ promo_section_link_classes }}">
+  <a href="{{ promo_section_url }}" class="block {{ promo_section_link_classes }}"{% if promo_section_alt == blank and promo_section_title != blank %} aria-label="{{ promo_section_title | escape }}"{% endif %}>
 {%- endif -%}
 
 {% if has_video %}

--- a/snippets/collection-promo-section.liquid
+++ b/snippets/collection-promo-section.liquid
@@ -15,12 +15,10 @@
   assign mobile_master = mobile_img | image_url
   assign desktop_master = desktop_img | image_url
 
-  # Accessible-name fallback: the link's name comes from the image alt; when blank
-  # (or for the video variant) fall back to a passed-in title so the link isn't nameless.
-  assign promo_section_alt = desktop_img.alt
-  if mobile_img != blank
-    assign promo_section_alt = mobile_img.alt
-  endif
+  # Accessible name for the banner. Authors set Image Alt Text per interrupter;
+  # when empty (easy to forget) fall back to the interrupter Title (always set),
+  # then the collection title. Rendered as the image alt so the link is named too.
+  assign promo_section_name = promo_section_alt_text | default: promo_section_title
 
   # The collection interrupter sits inside the padded page container on mobile.
   assign promo_sizes = promo_section_sizes | default: '(min-width: 400px) calc(100vw - 3rem), calc(100vw - 2rem)'
@@ -46,7 +44,7 @@
 -%}
 
 {%- if promo_section_url != blank -%}
-  <a href="{{ promo_section_url }}" class="block {{ promo_section_link_classes }}"{% if promo_section_alt == blank and promo_section_title != blank %} aria-label="{{ promo_section_title | escape }}"{% endif %}>
+  <a href="{{ promo_section_url }}" class="block {{ promo_section_link_classes }}"{% if has_video %} aria-label="{{ promo_section_name | escape }}"{% endif %}>
 {%- endif -%}
 
 {% if has_video %}
@@ -122,10 +120,10 @@
     <img
       {% if mobile_img != blank %}
         src="{% render 'imgix', src: mobile_master, w: 480 %}"
-        alt="{{ mobile_img.alt }}"
+        alt="{{ promo_section_name | escape }}"
       {% else %}
         src="{% render 'imgix', src: desktop_master, w: 960 %}"
-        alt="{{ desktop_img.alt }}"
+        alt="{{ promo_section_name | escape }}"
       {% endif %}
       loading="lazy"
       width="{{ dim_w }}"

--- a/snippets/collection-promo-tile.liquid
+++ b/snippets/collection-promo-tile.liquid
@@ -3,6 +3,7 @@
   - promo_tile_image: {ImageDrop} Liquid image object
   - promo_tile_url: {String} Link to promo tile destination (optional)
   - promo_tile_video: {VideoDrop} Liquid video object (optional)
+  - promo_tile_title: {String} Fallback link label used when the image has no alt text (optional)
 
   Usage:
   {% render 'collection-promo-tile', promo_tile_image: collection.metafields.image.url %}
@@ -14,7 +15,7 @@
     assign promo_tile_sizes = '(min-width: 1024px) calc((100vw - 6rem) / 4), (min-width: 768px) calc((100vw - 5rem) / 3), (min-width: 640px) calc((100vw - 4rem) / 2), (min-width: 400px) calc((100vw - 3.5rem) / 2), calc((100vw - 2.5rem) / 2)'
   -%}
   {%- if promo_tile_url != blank -%}
-    <a href="{{ promo_tile_url }}" class="block absolute inset-0 plp-tile-clickarea">
+    <a href="{{ promo_tile_url }}" class="block absolute inset-0 plp-tile-clickarea"{% if promo_tile_image.alt == blank and promo_tile_title != blank %} aria-label="{{ promo_tile_title | escape }}"{% endif %}>
   {%- else -%}
     <div>
   {%- endif -%}


### PR DESCRIPTION
## What & why

Screen readers announce a link by its accessible name. Several **promo image links** render with no name when the image `alt` is blank, so assistive tech reads out the raw URL instead of anything meaningful.

- **Promo image links** (collection promo tiles/sections + multicolumn column images): add an `aria-label` fallback to the collection title / block heading when the image `alt` is blank.
  - WCAG **F89** (Links must have an accessible name) — **~63 pages** in the 2026-06-25 live (oseamalibu.com) scan.
- **Featured-review 5-star SVG** (`product-clinicals`): add `role="img"` so its existing `aria-label="5 stars"` is a valid accessible name. WCAG **4.1.2**.

Markup-only — no visual change for sighted users.

## Scope

Re-cut cleanly from the `sortsite-link-names` work (**#106**), carrying **only** the still-valid live fixes and excluding:
- the **held** empty-button guards (`multicolumn` / `rich-text` — no production repro),
- the **#102** ATC price-label overlap,
- the obsolete careers change and an unrelated homepage image swap.

Intended to **replace #106** (to be closed, pointing here).

## Validation
- `shopify theme check`: 0 errors; no offense on any touched file.
- Prettier (project config): all 5 files clean.
- Merges clean into `main`.

**Files:** `product-clinicals.liquid`, `main-collection.liquid`, `multicolumn.liquid`, `collection-promo-section.liquid`, `collection-promo-tile.liquid`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
