### PR TITLE
Accessibility: wrap "Set includes" cards in <li> for valid list semantics (WCAG 1.3.1)

### DIFF
--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -322,7 +322,7 @@
                   <h2 class="mb-2 font-medium tracking-wide">Set includes</h2>
                   <ul>
                     {%- for product_in_set in product.metafields.custom.set_contains.value -%}
-                      <li>{%- render 'product-in-set', product: product_in_set -%}</li>
+                      <li class="mb-4 last:mb-0">{%- render 'product-in-set', product: product_in_set -%}</li>
                     {%- endfor -%}
                   </ul>
                 </div>

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -322,7 +322,7 @@
                   <h2 class="mb-2 font-medium tracking-wide">Set includes</h2>
                   <ul>
                     {%- for product_in_set in product.metafields.custom.set_contains.value -%}
-                      {%- render 'product-in-set', product: product_in_set -%}
+                      <li>{%- render 'product-in-set', product: product_in_set -%}</li>
                     {%- endfor -%}
                   </ul>
                 </div>


### PR DESCRIPTION
## What
The **Set includes** block on bundle/set PDPs rendered each `product-in-set` card as a direct `<div>` child of a `<ul>`, with no `<li>`. SortSite flagged this across all set/bundle product pages (ARIA 5.2.6 / WCAG 1.3.1 — *a `ul` must contain an `li` or `role=listitem`; its owned link/div elements have invalid roles*).

## Fix
In `sections/main-product.liquid`, wrap each rendered card in `<li>`, and move the card's `mb-4 last:mb-0` spacing onto the `<li>`.

```liquid
<ul>
  {%- for product_in_set in product.metafields.custom.set_contains.value -%}
    <li class="mb-4 last:mb-0">{%- render 'product-in-set', product: product_in_set -%}</li>
  {%- endfor -%}
</ul>
```

The card markup (`product-in-set.liquid`) is untouched.

## Why two commits
Wrapping each card in its own `<li>` made every card a `:last-child`, so the card's `last:mb-0` matched all of them and collapsed the inter-card gaps. The second commit moves `mb-4 last:mb-0` onto the `<li>` to restore the original 1rem spacing.

## Visual impact
**None** — confirmed on preview. 1rem between cards, 0 after the last, same as before; Tailwind preflight strips list bullets/indent so the `<li>` adds nothing visible. Only the DOM structure changes (`<ul> › <li> › <div card>` instead of `<ul> › <div card>`).

## Validation
- `shopify theme check`: 0 offenses on `main-product.liquid`, 0 error-severity offenses anywhere.
- Visually verified on `/products/bodycare-bestsellers-set` (4 cards, gaps intact).

## Affected pages
All set/bundle PDPs with a populated `set_contains` metafield — e.g. `bodycare-bestsellers-set`, `body-exfoliation-duo`, `body-glow-trio`, `body-hydration-heroes`, `cleanse-hydrate-duo`, `dream-bio-retinol-duo`. This is the bulk of the 27-page `<ul>` 1.3.1 finding. The remaining instances are content (blog rich-text) and possibly a vendor widget on `/pages/privacy-policy`, handled separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)