### PR TITLE
Fix Cartful skin quiz not loading (scope to its own page template)

### DIFF
--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -60,10 +60,6 @@
     <script src="{{ 'main.min.js' | asset_url }}" type="module"></script>
 
     <script>document.documentElement.className = document.documentElement.className.replace('no-js', 'js');</script>
-
-    <script>
-      ("function"===typeof window.CartfulQuiz?window.CartfulQuiz:undefined);(function(c,a,r,t,f,u,l){l=document.createElement(r),l.id=a+"scr",l.src=f,l.setAttribute("quizId",c),l.setAttribute("flowId",a),l.setAttribute("target",u),document[t].appendChild(l)})("0196d497-2404-7669-a07c-183285aa444e","019ddb81-2829-7ee5-9099-d741784ab87a","script","body","https://studio-assets.cartfulsolutions.com/embed/studio.js","page");
-    </script>
   </head>
 
   <body class="antialiased{% if template.name == 'product' %} pdp pdp-{{ product.handle }}{% elsif template.name == 'collection' %} plp plp-{{ collection.handle }}{% endif %}{% if customer %} logged-in{% endif %}">

--- a/templates/page.quiz-test.json
+++ b/templates/page.quiz-test.json
@@ -1,0 +1,17 @@
+{
+  "sections": {
+    "main": {
+      "type": "main-page",
+      "disabled": true,
+      "settings": {}
+    },
+    "custom_liquid_skin_quiz": {
+      "type": "custom-liquid",
+      "name": "t:sections.custom-liquid.presets.name",
+      "settings": {
+        "custom_liquid": "<div id=\"skin-quiz\"></div>\n<script>\n(function (c, a, r, t, f, u, l) {\n  l = document.createElement(r),\n  l.async = 1;\n  l.id = a + 'scr';\n  l.src = f;\n  l.setAttribute('quizId', c);\n  l.setAttribute('flowId', a);\n  l.setAttribute('target', u);\n  document[t].appendChild(l);\n})(\"0196d497-2404-7669-a07c-183285aa444e\", \"019ddb81-2829-7ee5-9099-d741784ab87a\", 'script', 'body', 'https://studio-assets.cartfulsolutions.com/embed/studio.js', 'page');\n</script>"
+      }
+    }
+  },
+  "order": ["main", "custom_liquid_skin_quiz"]
+}


### PR DESCRIPTION
## Summary
- The Cartful skin quiz script in `theme.liquid`'s `<head>` was appending its embed `<script>` to `document.body` before `<body>` existed in the DOM — it threw silently and never loaded, on every page.
- Removed the sitewide script from `theme.liquid`.
- Added `templates/page.quiz-test.json`, a dedicated template pairing the target `<div id="skin-quiz">` with the loader script in the page body — same pattern already used by `page.quiz-v2.json`.

## Follow-up needed in Shopify Admin (not in this repo)
- Assign the **quiz-test** template to `/pages/skin-quiz-test`.
- Remove the standalone `<div id="skin-quiz"></div>` currently typed into that page's content field, so it isn't duplicated.

## Test plan
- [ ] Preview this branch as a Shopify theme
- [ ] Assign the `quiz-test` template to `/pages/skin-quiz-test` on the preview theme
- [ ] Confirm the quiz widget renders on that page and no longer appears/errors elsewhere