### PR TITLE
Add accessibility content checker scaffold

### DIFF
--- a/.github/workflows/accessibility-content-check.yml
+++ b/.github/workflows/accessibility-content-check.yml
@@ -1,0 +1,51 @@
+name: Accessibility Content Check
+
+on:
+  workflow_dispatch:
+    inputs:
+      lookback_hours:
+        description: "How many hours of recently updated Shopify content to check"
+        required: false
+        default: "48"
+      limit:
+        description: "Maximum items per Shopify resource type"
+        required: false
+        default: "25"
+
+permissions:
+  contents: read
+
+jobs:
+  content-accessibility-check:
+    name: Check recently updated Shopify content
+    runs-on: ubuntu-latest
+    env:
+      LOOKBACK_HOURS: ${{ github.event.inputs.lookback_hours || '48' }}
+      CONTENT_CHECK_LIMIT: ${{ github.event.inputs.limit || '25' }}
+      SHOPIFY_SHOP_DOMAIN: ${{ secrets.SHOPIFY_SHOP_DOMAIN }}
+      SHOPIFY_ADMIN_TOKEN: ${{ secrets.SHOPIFY_ADMIN_TOKEN }}
+      SHOPIFY_STOREFRONT_DOMAIN: ${{ secrets.SHOPIFY_STOREFRONT_DOMAIN }}
+      SHOPIFY_API_VERSION: ${{ secrets.SHOPIFY_API_VERSION }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run accessibility content checker
+        run: npm run accessibility:content -- --output accessibility-content-report.md
+
+      - name: Upload report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: accessibility-content-report
+          path: accessibility-content-report.md
+          if-no-files-found: ignore

--- a/.github/workflows/accessibility-content-check.yml
+++ b/.github/workflows/accessibility-content-check.yml
@@ -1,8 +1,6 @@
 name: Accessibility Content Check
 
 on:
-  schedule:
-    - cron: "0 13 * * 1-5"
   workflow_dispatch:
     inputs:
       lookback_hours:

--- a/.github/workflows/accessibility-content-check.yml
+++ b/.github/workflows/accessibility-content-check.yml
@@ -1,6 +1,8 @@
 name: Accessibility Content Check
 
 on:
+  schedule:
+    - cron: "0 13 * * 1-5"
   workflow_dispatch:
     inputs:
       lookback_hours:

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ Thumbs.db
 node_modules
 .shopify
 .accessibility-content-report.md
+accessibility-content-report.md

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ ehthumbs.db
 Thumbs.db
 node_modules
 .shopify
+.accessibility-content-report.md

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "format": "prettier . --write",
     "format:check": "prettier . --check",
     "accessibility:content": "node tools/accessibility-content-checker/scan.mjs",
-    "accessibility:content:fixture": "node tools/accessibility-content-checker/scan.mjs --fixture tools/accessibility-content-checker/fixtures/sample-page.html --output .accessibility-content-report.md"
+    "accessibility:content:fixture": "node tools/accessibility-content-checker/scan.mjs --fixture tools/accessibility-content-checker/fixtures/sample-page.html --output accessibility-content-report.md --expect-findings 9"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
     "build": "vite build",
     "dev": "vite build --watch",
     "format": "prettier . --write",
-    "format:check": "prettier . --check"
+    "format:check": "prettier . --check",
+    "accessibility:content": "node tools/accessibility-content-checker/scan.mjs",
+    "accessibility:content:fixture": "node tools/accessibility-content-checker/scan.mjs --fixture tools/accessibility-content-checker/fixtures/sample-page.html --output .accessibility-content-report.md"
   },
   "repository": {
     "type": "git",

--- a/tools/accessibility-content-checker/README.md
+++ b/tools/accessibility-content-checker/README.md
@@ -17,7 +17,7 @@ The first version is read-only and report-only. It does not edit Shopify content
 
 The workflow is `.github/workflows/accessibility-content-check.yml`.
 
-It runs on a weekday schedule and can also be run manually from the GitHub Actions tab.
+It is manual-only for the first phase and can be run from the GitHub Actions tab.
 
 Required GitHub secrets:
 

--- a/tools/accessibility-content-checker/README.md
+++ b/tools/accessibility-content-checker/README.md
@@ -8,7 +8,7 @@ The first version is read-only and report-only. It does not edit Shopify content
 
 - Vague link/button labels such as `here`, `click here`, `read more`, and `learn more`.
 - Empty links or buttons.
-- `aria-label` values that do not include the visible link/button text.
+- Accessible names that do not include the visible link/button text.
 - Missing or empty image `alt` text.
 - Image `alt` text that looks like a file name.
 - Empty headings.

--- a/tools/accessibility-content-checker/README.md
+++ b/tools/accessibility-content-checker/README.md
@@ -1,0 +1,54 @@
+# Accessibility Content Checker
+
+This checker scans recently updated Shopify content for content-authored accessibility patterns that can become SortSite findings.
+
+The first version is read-only and report-only. It does not edit Shopify content or theme files.
+
+## Checks
+
+- Vague link/button labels such as `here`, `click here`, `read more`, and `learn more`.
+- Empty links or buttons.
+- `aria-label` values that do not include the visible link/button text.
+- Missing or empty image `alt` text.
+- Image `alt` text that looks like a file name.
+- Empty headings.
+
+## GitHub Action
+
+The workflow is `.github/workflows/accessibility-content-check.yml`.
+
+It runs on a weekday schedule and can also be run manually from the GitHub Actions tab.
+
+Required GitHub secrets:
+
+- `SHOPIFY_SHOP_DOMAIN`
+- `SHOPIFY_ADMIN_TOKEN`
+- `SHOPIFY_STOREFRONT_DOMAIN`
+- `SHOPIFY_API_VERSION`
+
+The Shopify app should be read-only and include these Admin API scopes:
+
+- `read_products`
+- `read_content` or `read_online_store_pages`
+- `read_files`
+
+## Local Dry Run
+
+Run the fixture scan:
+
+```bash
+npm run accessibility:content:fixture
+```
+
+Run against Shopify after adding local environment variables:
+
+```bash
+npm run accessibility:content
+```
+
+Optional variables:
+
+- `LOOKBACK_HOURS`: defaults to `48`.
+- `CONTENT_CHECK_LIMIT`: defaults to `25`.
+- `SHOPIFY_API_VERSION`: defaults to `2026-07`.
+

--- a/tools/accessibility-content-checker/README.md
+++ b/tools/accessibility-content-checker/README.md
@@ -24,7 +24,10 @@ Required GitHub secrets:
 - `SHOPIFY_SHOP_DOMAIN`
 - `SHOPIFY_ADMIN_TOKEN`
 - `SHOPIFY_STOREFRONT_DOMAIN`
-- `SHOPIFY_API_VERSION`
+
+Optional GitHub secret:
+
+- `SHOPIFY_API_VERSION` defaults to `2026-07` when omitted.
 
 The Shopify app should be read-only and include these Admin API scopes:
 

--- a/tools/accessibility-content-checker/fixtures/sample-page.html
+++ b/tools/accessibility-content-checker/fixtures/sample-page.html
@@ -14,11 +14,19 @@
         <a href="/products/body-serum" aria-label="Shop Hyaluronic Body Serum">Shop Body Serum</a>
       </p>
       <p><a href="/pages/customer-care"></a></p>
+      <p>
+        <a href="/products/body-serum-image">
+          <img src="/cdn/shop/files/body-serum-card.jpg" alt="Shop Hyaluronic Body Serum" />
+        </a>
+      </p>
 
       <button type="button"></button>
       <button type="button" aria-label="Open rewards details">Learn more</button>
+      <span id="rewards-label">Open rewards details</span>
+      <button type="button" aria-labelledby="rewards-label"></button>
 
       <img src="/cdn/shop/files/hbs-lifestyle.jpg" />
+      <img src="/cdn/shop/files/divider.svg" alt="" role="presentation" />
       <img src="/cdn/shop/files/banner-final.png" alt="banner-final.png" />
       <img
         src="/cdn/shop/files/body-serum.jpg"

--- a/tools/accessibility-content-checker/fixtures/sample-page.html
+++ b/tools/accessibility-content-checker/fixtures/sample-page.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <title>Accessibility content checker fixture</title>
+  </head>
+  <body>
+    <main>
+      <h1>Sample content</h1>
+      <h2></h2>
+
+      <p>Click <a href="/pages/privacy-policy">here</a> to read our policy.</p>
+      <p><a href="/blogs/skincare/example" aria-label="Read our skincare guide">Read more</a></p>
+      <p>
+        <a href="/products/body-serum" aria-label="Shop Hyaluronic Body Serum">Shop Body Serum</a>
+      </p>
+      <p><a href="/pages/customer-care"></a></p>
+
+      <button type="button"></button>
+      <button type="button" aria-label="Open rewards details">Learn more</button>
+
+      <img src="/cdn/shop/files/hbs-lifestyle.jpg" />
+      <img src="/cdn/shop/files/banner-final.png" alt="banner-final.png" />
+      <img
+        src="/cdn/shop/files/body-serum.jpg"
+        alt="Hyaluronic Body Serum bottle on a bathroom counter"
+      />
+    </main>
+  </body>
+</html>

--- a/tools/accessibility-content-checker/scan.mjs
+++ b/tools/accessibility-content-checker/scan.mjs
@@ -1,0 +1,757 @@
+import { readFile, writeFile, appendFile } from "node:fs/promises";
+import path from "node:path";
+
+const DEFAULT_API_VERSION = "2026-07";
+const DEFAULT_LOOKBACK_HOURS = 48;
+const DEFAULT_LIMIT = 25;
+const DEFAULT_OUTPUT = ".accessibility-content-report.md";
+
+const VAGUE_LABELS = new Set(["here", "click here", "read more", "learn more"]);
+
+const PRODUCTS_QUERY = `
+  query RecentlyUpdatedProducts($first: Int!, $query: String!) {
+    products(first: $first, query: $query, sortKey: UPDATED_AT, reverse: true) {
+      nodes {
+        title
+        handle
+        updatedAt
+        onlineStoreUrl
+        media(first: 25) {
+          nodes {
+            ... on MediaImage {
+              image {
+                url
+                altText
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
+const ARTICLES_QUERY = `
+  query RecentlyUpdatedArticles($first: Int!, $query: String!) {
+    articles(first: $first, query: $query, sortKey: UPDATED_AT, reverse: true) {
+      nodes {
+        title
+        handle
+        updatedAt
+        onlineStoreUrl
+        blog {
+          handle
+        }
+      }
+    }
+  }
+`;
+
+const PAGES_QUERY = `
+  query RecentlyUpdatedPages($first: Int!, $query: String!) {
+    pages(first: $first, query: $query, sortKey: UPDATED_AT, reverse: true) {
+      nodes {
+        title
+        handle
+        updatedAt
+        onlineStoreUrl
+      }
+    }
+  }
+`;
+
+const FILES_QUERY = `
+  query RecentlyUpdatedFiles($first: Int!, $query: String!) {
+    files(first: $first, query: $query, sortKey: UPDATED_AT, reverse: true) {
+      nodes {
+        id
+        createdAt
+        updatedAt
+        ... on MediaImage {
+          image {
+            url
+            altText
+          }
+        }
+      }
+    }
+  }
+`;
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const startedAt = new Date();
+  const warnings = [];
+  const sources = [];
+  const standaloneImages = [];
+
+  if (options.help) {
+    printHelp();
+    return;
+  }
+
+  if (options.fixture) {
+    const html = await readFile(options.fixture, "utf8");
+    sources.push({
+      type: "Fixture",
+      title: path.basename(options.fixture),
+      url: `fixture://${path.resolve(options.fixture)}`,
+      html,
+      updatedAt: null,
+      apiImages: [],
+    });
+  } else if (options.url) {
+    sources.push({
+      type: "URL",
+      title: options.url,
+      url: options.url,
+      html: null,
+      updatedAt: null,
+      apiImages: [],
+    });
+  } else {
+    const shopifySources = await getShopifySources(options, warnings);
+    sources.push(...shopifySources.sources);
+    standaloneImages.push(...shopifySources.standaloneImages);
+  }
+
+  const findings = [];
+
+  for (const source of sources) {
+    let html = source.html;
+
+    if (!html) {
+      try {
+        html = await fetchHtml(source.url);
+      } catch (error) {
+        warnings.push(`Could not fetch ${source.url}: ${error.message}`);
+        continue;
+      }
+    }
+
+    findings.push(...scanHtml(html, source));
+    findings.push(...scanApiImages(source.apiImages || [], source));
+  }
+
+  findings.push(...scanStandaloneImages(standaloneImages));
+
+  const report = buildReport({
+    startedAt,
+    options,
+    sources,
+    standaloneImages,
+    findings,
+    warnings,
+  });
+
+  await writeFile(options.output, report, "utf8");
+
+  if (process.env.GITHUB_STEP_SUMMARY) {
+    await appendFile(process.env.GITHUB_STEP_SUMMARY, report, "utf8");
+  }
+
+  console.log(`Accessibility content check complete.`);
+  console.log(`Sources checked: ${sources.length}`);
+  console.log(`Standalone images checked: ${standaloneImages.length}`);
+  console.log(`Findings: ${findings.length}`);
+  console.log(`Report: ${options.output}`);
+
+  if (options.failOnFindings && findings.length > 0) {
+    process.exitCode = 1;
+  }
+}
+
+function parseArgs(args) {
+  const options = {
+    fixture: null,
+    url: null,
+    output: DEFAULT_OUTPUT,
+    lookbackHours: numberFromEnv("LOOKBACK_HOURS", DEFAULT_LOOKBACK_HOURS),
+    limit: numberFromEnv("CONTENT_CHECK_LIMIT", DEFAULT_LIMIT),
+    failOnFindings: false,
+    help: false,
+  };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+
+    if (arg === "--fixture") {
+      options.fixture = args[++index];
+    } else if (arg === "--url") {
+      options.url = args[++index];
+    } else if (arg === "--output") {
+      options.output = args[++index];
+    } else if (arg === "--lookback-hours") {
+      options.lookbackHours = Number(args[++index]);
+    } else if (arg === "--limit") {
+      options.limit = Number(args[++index]);
+    } else if (arg === "--fail-on-findings") {
+      options.failOnFindings = true;
+    } else if (arg === "--help" || arg === "-h") {
+      options.help = true;
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  if (!Number.isFinite(options.lookbackHours) || options.lookbackHours <= 0) {
+    throw new Error("lookback hours must be a positive number");
+  }
+
+  if (!Number.isFinite(options.limit) || options.limit <= 0) {
+    throw new Error("limit must be a positive number");
+  }
+
+  return options;
+}
+
+function numberFromEnv(name, fallback) {
+  const value = Number(process.env[name]);
+  return Number.isFinite(value) && value > 0 ? value : fallback;
+}
+
+function printHelp() {
+  console.log(`
+Usage:
+  node tools/accessibility-content-checker/scan.mjs [options]
+
+Options:
+  --fixture <path>          Scan one local HTML fixture.
+  --url <url>               Scan one rendered URL.
+  --output <path>           Write markdown report. Defaults to ${DEFAULT_OUTPUT}.
+  --lookback-hours <hours>  Shopify updated content window. Defaults to ${DEFAULT_LOOKBACK_HOURS}.
+  --limit <count>           Max items per Shopify resource. Defaults to ${DEFAULT_LIMIT}.
+  --fail-on-findings        Exit non-zero when findings are present.
+`);
+}
+
+async function getShopifySources(options, warnings) {
+  const shopDomain = cleanShopDomain(requiredEnv("SHOPIFY_SHOP_DOMAIN"));
+  const token = requiredEnv("SHOPIFY_ADMIN_TOKEN");
+  const storefrontDomain = cleanStorefrontDomain(requiredEnv("SHOPIFY_STOREFRONT_DOMAIN"));
+  const apiVersion = process.env.SHOPIFY_API_VERSION || DEFAULT_API_VERSION;
+  const endpoint = `https://${shopDomain}/admin/api/${apiVersion}/graphql.json`;
+  const since = new Date(Date.now() - options.lookbackHours * 60 * 60 * 1000).toISOString();
+  const query = `updated_at:>=${since}`;
+  const variables = { first: options.limit, query };
+  const sources = [];
+  const standaloneImages = [];
+  let successfulCoreQueries = 0;
+
+  const productData = await safeShopifyQuery(
+    endpoint,
+    token,
+    PRODUCTS_QUERY,
+    variables,
+    warnings,
+    "products"
+  );
+  if (productData) {
+    successfulCoreQueries += 1;
+  }
+  for (const node of productData?.products?.nodes || []) {
+    sources.push({
+      type: "Product",
+      title: node.title,
+      url: node.onlineStoreUrl || `${storefrontDomain}/products/${node.handle}`,
+      updatedAt: node.updatedAt,
+      apiImages: mediaImagesFromProduct(node),
+    });
+  }
+
+  const articleData = await safeShopifyQuery(
+    endpoint,
+    token,
+    ARTICLES_QUERY,
+    variables,
+    warnings,
+    "articles"
+  );
+  if (articleData) {
+    successfulCoreQueries += 1;
+  }
+  for (const node of articleData?.articles?.nodes || []) {
+    const fallbackUrl = node.blog?.handle
+      ? `${storefrontDomain}/blogs/${node.blog.handle}/${node.handle}`
+      : null;
+
+    sources.push({
+      type: "Article",
+      title: node.title,
+      url: node.onlineStoreUrl || fallbackUrl,
+      updatedAt: node.updatedAt,
+      apiImages: [],
+    });
+  }
+
+  const pageData = await safeShopifyQuery(
+    endpoint,
+    token,
+    PAGES_QUERY,
+    variables,
+    warnings,
+    "pages"
+  );
+  if (pageData) {
+    successfulCoreQueries += 1;
+  }
+  for (const node of pageData?.pages?.nodes || []) {
+    sources.push({
+      type: "Page",
+      title: node.title,
+      url: node.onlineStoreUrl || `${storefrontDomain}/pages/${node.handle}`,
+      updatedAt: node.updatedAt,
+      apiImages: [],
+    });
+  }
+
+  if (successfulCoreQueries === 0) {
+    throw new Error(
+      "All core Shopify content queries failed. Check Admin API token, scopes, shop domain, and API version."
+    );
+  }
+
+  const fileData = await safeShopifyQuery(
+    endpoint,
+    token,
+    FILES_QUERY,
+    variables,
+    warnings,
+    "files"
+  );
+  for (const node of fileData?.files?.nodes || []) {
+    if (node.image?.url) {
+      standaloneImages.push({
+        type: "File",
+        title: fileNameFromUrl(node.image.url),
+        url: node.image.url,
+        alt: node.image.altText,
+        updatedAt: node.updatedAt,
+      });
+    }
+  }
+
+  return {
+    sources: sources.filter((source) => source.url),
+    standaloneImages,
+  };
+}
+
+function requiredEnv(name) {
+  if (!process.env[name]) {
+    throw new Error(`Missing required environment variable: ${name}`);
+  }
+
+  return process.env[name];
+}
+
+function cleanShopDomain(value) {
+  return value.replace(/^https?:\/\//, "").replace(/\/$/, "");
+}
+
+function cleanStorefrontDomain(value) {
+  const cleaned = value.replace(/\/$/, "");
+  return /^https?:\/\//.test(cleaned) ? cleaned : `https://${cleaned}`;
+}
+
+async function safeShopifyQuery(endpoint, token, query, variables, warnings, label) {
+  try {
+    return await shopifyGraphql(endpoint, token, query, variables);
+  } catch (error) {
+    warnings.push(`Could not query Shopify ${label}: ${error.message}`);
+    return null;
+  }
+}
+
+async function shopifyGraphql(endpoint, token, query, variables) {
+  const response = await fetch(endpoint, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-Shopify-Access-Token": token,
+    },
+    body: JSON.stringify({ query, variables }),
+  });
+
+  const payload = await response.json();
+
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status}: ${JSON.stringify(payload)}`);
+  }
+
+  if (payload.errors?.length) {
+    throw new Error(payload.errors.map((error) => error.message).join("; "));
+  }
+
+  return payload.data;
+}
+
+async function fetchHtml(url) {
+  const response = await fetch(url, {
+    headers: {
+      "User-Agent": "OSEA accessibility content checker",
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status}`);
+  }
+
+  return response.text();
+}
+
+function scanHtml(html, source) {
+  const normalizedHtml = stripIgnoredHtml(html);
+  return [
+    ...scanLinksAndButtons(normalizedHtml, source),
+    ...scanImages(normalizedHtml, source),
+    ...scanHeadings(normalizedHtml, source),
+  ];
+}
+
+function stripIgnoredHtml(html) {
+  return html
+    .replace(/<!--[\s\S]*?-->/g, "")
+    .replace(/<script\b[\s\S]*?<\/script>/gi, "")
+    .replace(/<style\b[\s\S]*?<\/style>/gi, "");
+}
+
+function scanLinksAndButtons(html, source) {
+  const findings = [];
+  const pattern = /<(a|button)\b([^>]*)>([\s\S]*?)<\/\1>/gi;
+  let match;
+
+  while ((match = pattern.exec(html))) {
+    const tag = match[1].toLowerCase();
+    const attrs = parseAttributes(match[2]);
+    const visibleText = normalizeText(textFromHtml(match[3]));
+    const ariaLabel = normalizeText(attrs["aria-label"] || "");
+    const accessibleName = ariaLabel || visibleText;
+    const labelForVagueCheck = visibleText || accessibleName;
+
+    if (!accessibleName) {
+      findings.push(
+        finding(
+          source,
+          "Empty link or button name",
+          tagSnippet(match[0]),
+          `${tag} has no visible text or aria-label.`
+        )
+      );
+      continue;
+    }
+
+    if (labelForVagueCheck && VAGUE_LABELS.has(normalizeForCompare(labelForVagueCheck))) {
+      findings.push(
+        finding(
+          source,
+          "Vague link or button label",
+          labelForVagueCheck,
+          `Label "${labelForVagueCheck}" may not explain the destination or action on its own.`
+        )
+      );
+    }
+
+    if (
+      visibleText &&
+      ariaLabel &&
+      !normalizeForCompare(ariaLabel).includes(normalizeForCompare(visibleText))
+    ) {
+      findings.push(
+        finding(
+          source,
+          "Visible label missing from aria-label",
+          tagSnippet(match[0]),
+          `Visible text "${visibleText}" is not included in aria-label "${ariaLabel}".`
+        )
+      );
+    }
+  }
+
+  return findings;
+}
+
+function scanImages(html, source) {
+  const findings = [];
+  const pattern = /<img\b([^>]*)>/gi;
+  let match;
+
+  while ((match = pattern.exec(html))) {
+    const attrs = parseAttributes(match[1]);
+    const src =
+      attrs.src || attrs["data-src"] || attrs.srcset || attrs["data-srcset"] || "unknown image";
+    const alt = attrs.alt;
+
+    if (alt === undefined || normalizeText(alt) === "") {
+      findings.push(
+        finding(
+          source,
+          "Missing or empty image alt text",
+          src,
+          "Image has no alt text or an empty alt attribute."
+        )
+      );
+      continue;
+    }
+
+    if (looksLikeFileName(alt)) {
+      findings.push(
+        finding(
+          source,
+          "Image alt text looks like a file name",
+          alt,
+          "Alt text should describe the image instead of repeating a file name."
+        )
+      );
+    }
+  }
+
+  return findings;
+}
+
+function scanHeadings(html, source) {
+  const findings = [];
+  const pattern = /<h([1-6])\b([^>]*)>([\s\S]*?)<\/h\1>/gi;
+  let match;
+
+  while ((match = pattern.exec(html))) {
+    const level = match[1];
+    const text = normalizeText(textFromHtml(match[3]));
+    const attrs = parseAttributes(match[2]);
+    const ariaLabel = normalizeText(attrs["aria-label"] || "");
+
+    if (!text && !ariaLabel) {
+      findings.push(
+        finding(
+          source,
+          "Empty heading",
+          tagSnippet(match[0]),
+          `h${level} has no visible text or aria-label.`
+        )
+      );
+    }
+  }
+
+  return findings;
+}
+
+function scanApiImages(images, source) {
+  const findings = [];
+
+  for (const image of images) {
+    const alt = normalizeText(image.alt || "");
+    const label = image.url || image.title || "API image";
+
+    if (!alt) {
+      findings.push(
+        finding(
+          source,
+          "Missing product media alt text",
+          label,
+          "Product media from Shopify Admin API is missing alt text."
+        )
+      );
+    } else if (looksLikeFileName(alt)) {
+      findings.push(
+        finding(
+          source,
+          "Product media alt text looks like a file name",
+          alt,
+          "Product media alt text should describe the image."
+        )
+      );
+    }
+  }
+
+  return findings;
+}
+
+function scanStandaloneImages(images) {
+  const findings = [];
+
+  for (const image of images) {
+    const source = {
+      type: image.type || "File",
+      title: image.title || fileNameFromUrl(image.url),
+      url: image.url,
+      updatedAt: image.updatedAt || null,
+    };
+    const alt = normalizeText(image.alt || "");
+
+    if (!alt) {
+      findings.push(
+        finding(
+          source,
+          "Missing uploaded image alt text",
+          image.url,
+          "Recently updated Shopify file is missing alt text."
+        )
+      );
+    } else if (looksLikeFileName(alt)) {
+      findings.push(
+        finding(
+          source,
+          "Uploaded image alt text looks like a file name",
+          alt,
+          "Uploaded image alt text should describe the image."
+        )
+      );
+    }
+  }
+
+  return findings;
+}
+
+function mediaImagesFromProduct(product) {
+  return (product.media?.nodes || [])
+    .map((node) => node.image)
+    .filter(Boolean)
+    .map((image) => ({
+      url: image.url,
+      alt: image.altText,
+    }));
+}
+
+function parseAttributes(attributeString) {
+  const attrs = {};
+  const pattern = /([\w:-]+)(?:\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'>`=]+)))?/g;
+  let match;
+
+  while ((match = pattern.exec(attributeString))) {
+    attrs[match[1].toLowerCase()] = match[2] ?? match[3] ?? match[4] ?? "";
+  }
+
+  return attrs;
+}
+
+function textFromHtml(html) {
+  return decodeHtmlEntities(html.replace(/<[^>]*>/g, " "));
+}
+
+function decodeHtmlEntities(value) {
+  return value
+    .replace(/&nbsp;/g, " ")
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'");
+}
+
+function normalizeText(value) {
+  return decodeHtmlEntities(String(value || ""))
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function normalizeForCompare(value) {
+  return normalizeText(value).toLowerCase().replace(/\s+/g, " ");
+}
+
+function looksLikeFileName(value) {
+  const normalized = normalizeText(value).toLowerCase();
+  return (
+    /\.(jpe?g|png|webp|gif|svg|avif)$/i.test(normalized) ||
+    /^img[_-]?\d+/.test(normalized) ||
+    /^[a-z0-9_-]+\.(jpe?g|png|webp|gif|svg|avif)$/i.test(normalized) ||
+    /^[a-z0-9_-]+(?:final|copy|desktop|mobile|banner|image)[a-z0-9_.-]*$/i.test(normalized)
+  );
+}
+
+function fileNameFromUrl(url) {
+  try {
+    return path.basename(new URL(url).pathname);
+  } catch {
+    return url;
+  }
+}
+
+function tagSnippet(tag) {
+  return normalizeText(tag).slice(0, 220);
+}
+
+function finding(source, issue, found, reason) {
+  return {
+    sourceType: source.type,
+    title: source.title,
+    url: source.url,
+    updatedAt: source.updatedAt,
+    issue,
+    found,
+    reason,
+  };
+}
+
+function buildReport({ startedAt, options, sources, standaloneImages, findings, warnings }) {
+  const lines = [];
+  const groupedFindings = groupFindings(findings);
+
+  lines.push("# Accessibility Content Check Report");
+  lines.push("");
+  lines.push(`Generated: ${startedAt.toISOString()}`);
+  lines.push(`Lookback hours: ${options.lookbackHours}`);
+  lines.push(`Rendered sources checked: ${sources.length}`);
+  lines.push(`Standalone images checked: ${standaloneImages.length}`);
+  lines.push(`Findings: ${findings.length}`);
+  lines.push("");
+
+  if (warnings.length) {
+    lines.push("## Warnings");
+    lines.push("");
+    for (const warning of warnings) {
+      lines.push(`- ${warning}`);
+    }
+    lines.push("");
+  }
+
+  if (!findings.length) {
+    lines.push("## Result");
+    lines.push("");
+    lines.push("No content accessibility findings were detected in the checked content.");
+    lines.push("");
+    return lines.join("\n");
+  }
+
+  lines.push("## Findings");
+  lines.push("");
+
+  for (const [sourceLabel, sourceFindings] of groupedFindings) {
+    lines.push(`### ${sourceLabel}`);
+    lines.push("");
+
+    for (const item of sourceFindings) {
+      lines.push(`- **${item.issue}**`);
+      lines.push(`  - Found: \`${markdownInline(item.found)}\``);
+      lines.push(`  - Reason: ${item.reason}`);
+    }
+
+    lines.push("");
+  }
+
+  return lines.join("\n");
+}
+
+function groupFindings(findings) {
+  const grouped = new Map();
+
+  for (const item of findings) {
+    const label = `${item.sourceType}: ${item.title || "Untitled"} (${item.url})`;
+
+    if (!grouped.has(label)) {
+      grouped.set(label, []);
+    }
+
+    grouped.get(label).push(item);
+  }
+
+  return grouped;
+}
+
+function markdownInline(value) {
+  return normalizeText(value).replace(/`/g, "\\`");
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/tools/accessibility-content-checker/scan.mjs
+++ b/tools/accessibility-content-checker/scan.mjs
@@ -129,8 +129,11 @@ async function main() {
       }
     }
 
-    findings.push(...scanHtml(html, source));
-    findings.push(...scanApiImages(source.apiImages || [], source));
+    const htmlFindings = scanHtml(html, source);
+    findings.push(...htmlFindings);
+    findings.push(
+      ...scanApiImages(source.apiImages || [], source, reportedImageUrls(htmlFindings))
+    );
   }
 
   findings.push(...scanStandaloneImages(standaloneImages));
@@ -232,7 +235,7 @@ async function getShopifySources(options, warnings) {
   const apiVersion = process.env.SHOPIFY_API_VERSION || DEFAULT_API_VERSION;
   const endpoint = `https://${shopDomain}/admin/api/${apiVersion}/graphql.json`;
   const since = new Date(Date.now() - options.lookbackHours * 60 * 60 * 1000).toISOString();
-  const query = `updated_at:>=${since}`;
+  const query = `updated_at:>='${since}'`;
   const variables = { first: options.limit, query };
   const sources = [];
   const standaloneImages = [];
@@ -427,7 +430,6 @@ function scanLinksAndButtons(html, source) {
     const visibleText = normalizeText(textFromHtml(match[3]));
     const ariaLabel = normalizeText(attrs["aria-label"] || "");
     const accessibleName = ariaLabel || visibleText;
-    const labelForVagueCheck = visibleText || accessibleName;
 
     if (!accessibleName) {
       findings.push(
@@ -441,13 +443,13 @@ function scanLinksAndButtons(html, source) {
       continue;
     }
 
-    if (labelForVagueCheck && VAGUE_LABELS.has(normalizeForCompare(labelForVagueCheck))) {
+    if (accessibleName && VAGUE_LABELS.has(normalizeForCompare(accessibleName))) {
       findings.push(
         finding(
           source,
           "Vague link or button label",
-          labelForVagueCheck,
-          `Label "${labelForVagueCheck}" may not explain the destination or action on its own.`
+          accessibleName,
+          `Label "${accessibleName}" may not explain the destination or action on its own.`
         )
       );
     }
@@ -481,6 +483,7 @@ function scanImages(html, source) {
     const src =
       attrs.src || attrs["data-src"] || attrs.srcset || attrs["data-srcset"] || "unknown image";
     const alt = attrs.alt;
+    const imageUrl = normalizeImageUrl(src, source.url);
 
     if (alt === undefined || normalizeText(alt) === "") {
       findings.push(
@@ -488,7 +491,8 @@ function scanImages(html, source) {
           source,
           "Missing or empty image alt text",
           src,
-          "Image has no alt text or an empty alt attribute."
+          "Image has no alt text or an empty alt attribute.",
+          { imageUrl }
         )
       );
       continue;
@@ -500,7 +504,8 @@ function scanImages(html, source) {
           source,
           "Image alt text looks like a file name",
           alt,
-          "Alt text should describe the image instead of repeating a file name."
+          "Alt text should describe the image instead of repeating a file name.",
+          { imageUrl }
         )
       );
     }
@@ -535,12 +540,17 @@ function scanHeadings(html, source) {
   return findings;
 }
 
-function scanApiImages(images, source) {
+function scanApiImages(images, source, seenImageUrls = new Set()) {
   const findings = [];
 
   for (const image of images) {
     const alt = normalizeText(image.alt || "");
     const label = image.url || image.title || "API image";
+    const imageUrl = normalizeImageUrl(image.url);
+
+    if (imageUrl && seenImageUrls.has(imageUrl)) {
+      continue;
+    }
 
     if (!alt) {
       findings.push(
@@ -548,7 +558,8 @@ function scanApiImages(images, source) {
           source,
           "Missing product media alt text",
           label,
-          "Product media from Shopify Admin API is missing alt text."
+          "Product media from Shopify Admin API is missing alt text.",
+          { imageUrl }
         )
       );
     } else if (looksLikeFileName(alt)) {
@@ -557,7 +568,8 @@ function scanApiImages(images, source) {
           source,
           "Product media alt text looks like a file name",
           alt,
-          "Product media alt text should describe the image."
+          "Product media alt text should describe the image.",
+          { imageUrl }
         )
       );
     }
@@ -577,6 +589,7 @@ function scanStandaloneImages(images) {
       updatedAt: image.updatedAt || null,
     };
     const alt = normalizeText(image.alt || "");
+    const imageUrl = normalizeImageUrl(image.url);
 
     if (!alt) {
       findings.push(
@@ -584,7 +597,8 @@ function scanStandaloneImages(images) {
           source,
           "Missing uploaded image alt text",
           image.url,
-          "Recently updated Shopify file is missing alt text."
+          "Recently updated Shopify file is missing alt text.",
+          { imageUrl }
         )
       );
     } else if (looksLikeFileName(alt)) {
@@ -593,7 +607,8 @@ function scanStandaloneImages(images) {
           source,
           "Uploaded image alt text looks like a file name",
           alt,
-          "Uploaded image alt text should describe the image."
+          "Uploaded image alt text should describe the image.",
+          { imageUrl }
         )
       );
     }
@@ -658,6 +673,37 @@ function looksLikeFileName(value) {
   );
 }
 
+function reportedImageUrls(findings) {
+  return new Set(findings.map((item) => item.imageUrl).filter(Boolean));
+}
+
+function normalizeImageUrl(value, baseUrl) {
+  const candidate = firstImageCandidate(value);
+
+  if (!candidate) {
+    return "";
+  }
+
+  try {
+    const url = new URL(candidate, baseUrl);
+    url.hash = "";
+    url.search = "";
+    return url.href.replace(/^https?:/, "");
+  } catch {
+    return candidate.split("?")[0].replace(/^https?:/, "");
+  }
+}
+
+function firstImageCandidate(value) {
+  const normalized = normalizeText(value);
+
+  if (!normalized || normalized === "unknown image") {
+    return "";
+  }
+
+  return normalized.split(",")[0].trim().split(/\s+/)[0];
+}
+
 function fileNameFromUrl(url) {
   try {
     return path.basename(new URL(url).pathname);
@@ -670,7 +716,7 @@ function tagSnippet(tag) {
   return normalizeText(tag).slice(0, 220);
 }
 
-function finding(source, issue, found, reason) {
+function finding(source, issue, found, reason, details = {}) {
   return {
     sourceType: source.type,
     title: source.title,
@@ -679,6 +725,7 @@ function finding(source, issue, found, reason) {
     issue,
     found,
     reason,
+    ...details,
   };
 }
 

--- a/tools/accessibility-content-checker/scan.mjs
+++ b/tools/accessibility-content-checker/scan.mjs
@@ -4,7 +4,7 @@ import path from "node:path";
 const DEFAULT_API_VERSION = "2026-07";
 const DEFAULT_LOOKBACK_HOURS = 48;
 const DEFAULT_LIMIT = 25;
-const DEFAULT_OUTPUT = ".accessibility-content-report.md";
+const DEFAULT_OUTPUT = "accessibility-content-report.md";
 
 const VAGUE_LABELS = new Set(["here", "click here", "read more", "learn more"]);
 
@@ -129,10 +129,16 @@ async function main() {
       }
     }
 
+    if (!source.html && looksLikeShopifyPasswordPage(html)) {
+      warnings.push(
+        `Fetched a storefront password page for ${source.url}. Rendered HTML checks may not reflect the actual content.`
+      );
+    }
+
     const htmlFindings = scanHtml(html, source);
     findings.push(...htmlFindings);
     findings.push(
-      ...scanApiImages(source.apiImages || [], source, reportedImageUrls(htmlFindings))
+      ...scanApiImages(source.apiImages || [], source, renderedImageUrls(html, source.url))
     );
   }
 
@@ -159,6 +165,12 @@ async function main() {
   console.log(`Findings: ${findings.length}`);
   console.log(`Report: ${options.output}`);
 
+  if (options.expectFindings !== null && findings.length !== options.expectFindings) {
+    console.error(`Expected ${options.expectFindings} findings, but found ${findings.length}.`);
+    process.exitCode = 1;
+    return;
+  }
+
   if (options.failOnFindings && findings.length > 0) {
     process.exitCode = 1;
   }
@@ -171,6 +183,7 @@ function parseArgs(args) {
     output: DEFAULT_OUTPUT,
     lookbackHours: numberFromEnv("LOOKBACK_HOURS", DEFAULT_LOOKBACK_HOURS),
     limit: numberFromEnv("CONTENT_CHECK_LIMIT", DEFAULT_LIMIT),
+    expectFindings: null,
     failOnFindings: false,
     help: false,
   };
@@ -188,6 +201,8 @@ function parseArgs(args) {
       options.lookbackHours = Number(args[++index]);
     } else if (arg === "--limit") {
       options.limit = Number(args[++index]);
+    } else if (arg === "--expect-findings") {
+      options.expectFindings = Number(args[++index]);
     } else if (arg === "--fail-on-findings") {
       options.failOnFindings = true;
     } else if (arg === "--help" || arg === "-h") {
@@ -203,6 +218,13 @@ function parseArgs(args) {
 
   if (!Number.isFinite(options.limit) || options.limit <= 0) {
     throw new Error("limit must be a positive number");
+  }
+
+  if (
+    options.expectFindings !== null &&
+    (!Number.isInteger(options.expectFindings) || options.expectFindings < 0)
+  ) {
+    throw new Error("expected findings must be a non-negative integer");
   }
 
   return options;
@@ -224,6 +246,7 @@ Options:
   --output <path>           Write markdown report. Defaults to ${DEFAULT_OUTPUT}.
   --lookback-hours <hours>  Shopify updated content window. Defaults to ${DEFAULT_LOOKBACK_HOURS}.
   --limit <count>           Max items per Shopify resource. Defaults to ${DEFAULT_LIMIT}.
+  --expect-findings <count> Exit non-zero unless the finding count matches.
   --fail-on-findings        Exit non-zero when findings are present.
 `);
 }
@@ -403,10 +426,18 @@ async function fetchHtml(url) {
   return response.text();
 }
 
+function looksLikeShopifyPasswordPage(html) {
+  return (
+    /<form\b[^>]*\baction=["']\/password["']/i.test(html) || /shopify-section-password/i.test(html)
+  );
+}
+
 function scanHtml(html, source) {
   const normalizedHtml = stripIgnoredHtml(html);
+  const labelsById = textById(normalizedHtml);
+
   return [
-    ...scanLinksAndButtons(normalizedHtml, source),
+    ...scanLinksAndButtons(normalizedHtml, source, labelsById),
     ...scanImages(normalizedHtml, source),
     ...scanHeadings(normalizedHtml, source),
   ];
@@ -419,7 +450,7 @@ function stripIgnoredHtml(html) {
     .replace(/<style\b[\s\S]*?<\/style>/gi, "");
 }
 
-function scanLinksAndButtons(html, source) {
+function scanLinksAndButtons(html, source, labelsById = new Map()) {
   const findings = [];
   const pattern = /<(a|button)\b([^>]*)>([\s\S]*?)<\/\1>/gi;
   let match;
@@ -429,7 +460,8 @@ function scanLinksAndButtons(html, source) {
     const attrs = parseAttributes(match[2]);
     const visibleText = normalizeText(textFromHtml(match[3]));
     const ariaLabel = normalizeText(attrs["aria-label"] || "");
-    const accessibleName = ariaLabel || visibleText;
+    const labelledByName = accessibleNameFromLabelledBy(attrs["aria-labelledby"], labelsById);
+    const accessibleName = labelledByName || ariaLabel || accessibleNameFromContent(match[3]);
 
     if (!accessibleName) {
       findings.push(
@@ -437,7 +469,7 @@ function scanLinksAndButtons(html, source) {
           source,
           "Empty link or button name",
           tagSnippet(match[0]),
-          `${tag} has no visible text or aria-label.`
+          `${tag} has no visible text or accessible name.`
         )
       );
       continue;
@@ -456,15 +488,15 @@ function scanLinksAndButtons(html, source) {
 
     if (
       visibleText &&
-      ariaLabel &&
-      !normalizeForCompare(ariaLabel).includes(normalizeForCompare(visibleText))
+      (ariaLabel || labelledByName) &&
+      !normalizeForCompare(accessibleName).includes(normalizeForCompare(visibleText))
     ) {
       findings.push(
         finding(
           source,
-          "Visible label missing from aria-label",
+          "Visible label missing from accessible name",
           tagSnippet(match[0]),
-          `Visible text "${visibleText}" is not included in aria-label "${ariaLabel}".`
+          `Visible text "${visibleText}" is not included in accessible name "${accessibleName}".`
         )
       );
     }
@@ -484,6 +516,10 @@ function scanImages(html, source) {
       attrs.src || attrs["data-src"] || attrs.srcset || attrs["data-srcset"] || "unknown image";
     const alt = attrs.alt;
     const imageUrl = normalizeImageUrl(src, source.url);
+
+    if (isDecorativeImage(attrs)) {
+      continue;
+    }
 
     if (alt === undefined || normalizeText(alt) === "") {
       findings.push(
@@ -627,6 +663,31 @@ function mediaImagesFromProduct(product) {
     }));
 }
 
+function renderedImageUrls(html, baseUrl) {
+  const urls = new Set();
+  const normalizedHtml = stripIgnoredHtml(html);
+  const pattern = /<img\b([^>]*)>/gi;
+  let match;
+
+  while ((match = pattern.exec(normalizedHtml))) {
+    const attrs = parseAttributes(match[1]);
+
+    for (const value of imageSourceValues(attrs)) {
+      const imageUrl = normalizeImageUrl(value, baseUrl);
+
+      if (imageUrl) {
+        urls.add(imageUrl);
+      }
+    }
+  }
+
+  return urls;
+}
+
+function imageSourceValues(attrs) {
+  return [attrs.src, attrs["data-src"], attrs.srcset, attrs["data-srcset"]].filter(Boolean);
+}
+
 function parseAttributes(attributeString) {
   const attrs = {};
   const pattern = /([\w:-]+)(?:\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'>`=]+)))?/g;
@@ -637,6 +698,46 @@ function parseAttributes(attributeString) {
   }
 
   return attrs;
+}
+
+function textById(html) {
+  const labels = new Map();
+  const pattern = /<([a-z][\w:-]*)\b([^>]*\bid\s*=[^>]*)>([\s\S]*?)<\/\1>/gi;
+  let match;
+
+  while ((match = pattern.exec(html))) {
+    const attrs = parseAttributes(match[2]);
+
+    if (attrs.id) {
+      labels.set(attrs.id, normalizeText(textFromHtmlWithAlt(match[3])));
+    }
+  }
+
+  return labels;
+}
+
+function accessibleNameFromLabelledBy(value, labelsById) {
+  return normalizeText(
+    String(value || "")
+      .split(/\s+/)
+      .map((id) => labelsById.get(id) || "")
+      .join(" ")
+  );
+}
+
+function accessibleNameFromContent(html) {
+  return normalizeText(textFromHtmlWithAlt(html));
+}
+
+function textFromHtmlWithAlt(html) {
+  return textFromHtml(
+    html
+      .replace(/<img\b([^>]*)>/gi, (_tag, attrsText) => {
+        const attrs = parseAttributes(attrsText);
+        return attrs.alt ? ` ${attrs.alt} ` : " ";
+      })
+      .replace(/<svg\b[\s\S]*?<title\b[^>]*>([\s\S]*?)<\/title>[\s\S]*?<\/svg>/gi, " $1 ")
+  );
 }
 
 function textFromHtml(html) {
@@ -673,8 +774,11 @@ function looksLikeFileName(value) {
   );
 }
 
-function reportedImageUrls(findings) {
-  return new Set(findings.map((item) => item.imageUrl).filter(Boolean));
+function isDecorativeImage(attrs) {
+  const role = normalizeForCompare(attrs.role || "");
+  const ariaHidden = normalizeForCompare(attrs["aria-hidden"] || "");
+
+  return role === "presentation" || role === "none" || ariaHidden === "true";
 }
 
 function normalizeImageUrl(value, baseUrl) {
@@ -688,9 +792,9 @@ function normalizeImageUrl(value, baseUrl) {
     const url = new URL(candidate, baseUrl);
     url.hash = "";
     url.search = "";
-    return url.href.replace(/^https?:/, "");
+    return `//${url.hostname.toLowerCase()}${normalizeImagePath(url.pathname)}`;
   } catch {
-    return candidate.split("?")[0].replace(/^https?:/, "");
+    return normalizeImagePath(candidate.split("?")[0]).replace(/^https?:/, "");
   }
 }
 
@@ -702,6 +806,23 @@ function firstImageCandidate(value) {
   }
 
   return normalized.split(",")[0].trim().split(/\s+/)[0];
+}
+
+function normalizeImagePath(pathname) {
+  return safeDecodeURIComponent(pathname)
+    .replace(
+      /_(?:pico|icon|thumb|small|compact|medium|large|grande|original|master)(?=\.[a-z]+$)/i,
+      ""
+    )
+    .replace(/_\d+x\d*(?:_crop_[a-z]+)?(?=\.[a-z]+$)/i, "");
+}
+
+function safeDecodeURIComponent(value) {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
 }
 
 function fileNameFromUrl(url) {


### PR DESCRIPTION
## Summary
- Adds a report-only accessibility content checker for recently updated Shopify content.
- Adds a manual GitHub Action workflow to run the checker.
- Adds fixture mode for local validation.

## Checks Included
- Vague link/button labels
- Empty links/buttons
- aria-label visible text mismatches
- Missing/empty image alt text
- Filename-like alt text
- Empty headings

## Notes
- Workflow is manual-only for now.
- No auto-fixes.
- No AI suggestions.
- No server required.
- Shopify credentials must be added through GitHub Actions secrets before running against real store content.

## Validation
- `npm run accessibility:content:fixture`
- `node --check tools/accessibility-content-checker/scan.mjs`
- `npx prettier --check .github/workflows/accessibility-content-check.yml tools/accessibility-content-checker/README.md tools/accessibility-content-checker/fixtures/sample-page.html tools/accessibility-content-checker/scan.mjs package.json`