### PR TITLE
Fix announcement carousel accessibility markup

### DIFF
--- a/sections/announcement-bar.liquid
+++ b/sections/announcement-bar.liquid
@@ -59,6 +59,9 @@
       class="glide type-carousel gap-0 autoplay-{{ section.settings.slide_interval | times: 1000 }} max-w-xl mx-auto"
       id="slider-announcement-bar"
       data-breakpoint-limit="none"
+      data-sr-active-slide-only="true"
+      role="region"
+      aria-label="Announcements"
     >
       <div class="glide__track" data-glide-el="track">
         <ul class="glide__slides pb-0">
@@ -70,7 +73,7 @@
                   echo '<p class="' | append: text_classes | append: '">'
                 endcapture
               -%}
-              <li class="glide__slide" role="region" aria-label="{{ block.settings.text | strip_html }}">
+              <li class="glide__slide">
                 {{ block.settings.text | replace: '<p>', text_tag }}
               </li>
             {%- endif -%}


### PR DESCRIPTION
## What changed

- Keeps each announcement slide as a native list item.
- Names the overall announcement carousel as one accessible region.
- Enables the carousel's existing handling for cloned and inactive slides.

## Why

Each announcement `<li>` was assigned `role="region"`. That replaced its native list-item meaning and caused Priority 1 Accessibility and HTML Standards findings across the audited pages.

The region semantics now belong to the overall carousel, while each slide keeps its correct list-item meaning.

## Impact

There should be no visual or business-behavior change. Announcement text, links, arrow controls, autoplay timing, responsive layout, and shared Glide JavaScript are unchanged.

## Validation

- Focused SortSite scan: Accessibility reports 0 issues and Errors reports 0 issues.
- SortSite target rules `AccAriaRoleInvalid` and `W3cHtml5Error-RnvErAval-role` are absent.
- Manual checks passed for appearance, autoplay, arrow controls, and keyboard activation.
- `npm run build` passed.
- `shopify theme check --fail-level error` passed with 47 existing warnings and no errors.
- `git diff --check` passed.

## Existing baseline notes

- Repository-wide `npm run format:check` reports existing formatting failures across 222 files; the changed Liquid file is not among those reported files.
- No dependencies were changed.