### PR TITLE
Fix invalid markup in mobile submenu buttons

### DIFF
--- a/sections/header.liquid
+++ b/sections/header.liquid
@@ -65,12 +65,12 @@
                               <span class="py-2 pl-6 sm:pl-8 pr-2"{% if link.current %} aria-current="page"{% endif %}>
                                 {{- link.title | escape -}}
                               </span>
-                              <div class="flex min-h-10 w-10 items-center justify-center">
+                              <span class="flex min-h-10 w-10 items-center justify-center">
                                 <svg aria-hidden="true" focusable="false" class="w-4 h-4 flex items-center justify-center" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                                   <line x1="12" y1="5" x2="12" y2="19" class="motion-safe:transition-transform origin-center" data-hamburger-submenu-toggle-line/>
                                   <line x1="5" y1="12" x2="19" y2="12" />
                                 </svg>
-                              </div>
+                              </span>
                             </button>
                             <ul id="HamburgerSubmenu-{{ forloop.index }}" class="px-8 pb-2" hidden data-hamburger-submenu>
                               {%- for childlink in link.links -%}


### PR DESCRIPTION
## What changed

Changes the mobile submenu icon wrapper from a `div` to a `span`.

## Why

The icon wrapper was rendered inside a `button`, where a block-level `div` is invalid. SortSite reported this under the Priority 1 HTML Standards rule `W3cHtml5Error-RnvErElem-div`.

The outer submenu container remains a `div`. This preserves the current JavaScript-controlled submenu architecture and full-row button behavior.

## Impact

There should be no visual or functional change. All existing classes, SVG markup, data attributes, `aria-expanded`, `aria-controls`, icon animation, and menu JavaScript remain unchanged.

## Validation

- Focused SortSite comparison on `/products/undaria-algae-body-wash`:
  - shared invalid-`div` rule dropped from 9 rendered instances to 5
  - all 4 mobile-menu instances were removed
  - remaining 5 instances belong to unrelated cart, product, and footer markup
  - no new Priority 1 rule type appeared
  - Accessibility and Errors remained at 0
- Rendered DOM contains 4 submenu buttons, 0 invalid icon-wrapper divs, and 4 valid icon-wrapper spans.
- Manual mobile checks passed for all submenu rows, plus/minus animation, keyboard activation, Escape behavior, focus return, and alignment.
- `npm run build` passed.
- `shopify theme check --fail-level error` passed with 47 existing warnings and no errors.
- `git diff --check` passed.

## Existing baseline notes

- Repository-wide `npm run format:check` reports existing formatting failures across 222 files; `sections/header.liquid` is not among the reported files.
- No JavaScript, compiled assets, dependencies, or integration code were changed.