### PR TITLE
Fix product slider video thumbnail markup

### DIFF
--- a/snippets/product-image-slider.liquid
+++ b/snippets/product-image-slider.liquid
@@ -178,9 +178,9 @@ Accepts:
         {%- if media.media_type == 'image' -%}
           <span class="block w-2 h-2 rounded-full glide__bullet-icon bg-seaweed-700 md:hidden"></span>
         {%- elsif media.media_type == 'video' -%}
-          <div class="absolute top-1/2 left-1/2 z-10 w-5 h-5 bg-transparent rounded-full -translate-x-1/2 -translate-y-1/2 glide__bullet-icon md:w-8 md:h-8 md:bg-white/50">
+          <span class="absolute top-1/2 left-1/2 z-10 w-5 h-5 bg-transparent rounded-full -translate-x-1/2 -translate-y-1/2 glide__bullet-icon md:w-8 md:h-8 md:bg-white/50">
             {%- render 'icon-play', classes: 'absolute inset-0 scale-75 md:text-white md:ml-0.5' -%}
-          </div>
+          </span>
         {%- endif -%}
 
         {%- liquid


### PR DESCRIPTION
## Summary

- replace the video-thumbnail play-icon wrapper from `div` to `span`
- preserve all existing Tailwind classes and Glide carousel behavior
- remove the invalid block element nested inside the visual-only thumbnail `span`

## Root cause

The product media slider rendered a `div` inside a `span[data-glide-dir]` for video thumbnails. SortSite correctly reported this as invalid HTML. The wrapper only provides positioning and styling, so a `span` is the appropriate phrasing element.

## Impact

There is no intended visual or behavioral change. Product video thumbnails retain the same play icon, select the correct slide, and continue playing normally.

## Validation

- `npm run build` — passed
- `shopify theme check` — completed with existing repository warnings only
- `git diff --check` — passed
- local Undaria Algae Body Wash PDP rendered one corrected wrapper and zero old wrappers
- manual visual and video-thumbnail playback verification — passed
- targeted SortSite product-slider occurrence — reduced from 1 to 0

The generic invalid-`div` rule remains on the PDP for separate cart and third-party markup outside this PR.