### PR TITLE
Fix conditional checked attribute spacing

### DIFF
--- a/sections/multicolumn.liquid
+++ b/sections/multicolumn.liquid
@@ -241,7 +241,7 @@
                                       name="selling_plan"
                                       value="{{ option.id }}"
                                       form="{{ product_form_id }}"
-                                      {%- if option.id == default_option -%}checked{%- endif -%}
+                                      {% if option.id == default_option %}checked{% endif %}
                                     >
                                     <label
                                       class="button button-xs lowercase button-secondary peer-checked:border-seaweed-4 peer-checked:bg-wave-200 px-1 tracking-normal w-full text-left"

--- a/snippets/card-product.liquid
+++ b/snippets/card-product.liquid
@@ -181,7 +181,7 @@
                         name="selling_plan"
                         value="{{ option.id }}"
                         form="{{ product_form_id }}"
-                        {%- if option.id == default_option -%}checked{%- endif -%}
+                        {% if option.id == default_option %}checked{% endif %}
                       >
                       <label
                         class="button button-xs lowercase button-secondary peer-checked:border-seaweed-4 peer-checked:bg-wave-200 px-1 tracking-normal w-full text-left"


### PR DESCRIPTION
## Summary
- preserve whitespace before conditionally rendered `checked` attributes in product-card subscription controls
- apply the same correction to multicolumn product blocks

## Root cause
Liquid whitespace-control markers removed the newline before `checked`, producing invalid HTML such as `form="…"checked`.

## Impact
Subscription defaults and interactions are unchanged; rendered markup is now valid.

## Validation
- SortSite: `No space between attributes` P1 rule removed (present before, absent after)
- Official W3C validator: zero no-space errors on the homepage and PDP
- Browser test: all eight homepage subscription groups switched intervals and restored defaults
- Visual check: subscription carousel renders correctly
- `npm run build`
- `shopify theme check` (passes with existing warnings)
- `git diff --check`