### PR TITLE
Fix duplicate IDs and clinical citation markup

### DIFF
--- a/sections/footer.liquid
+++ b/sections/footer.liquid
@@ -128,12 +128,12 @@
                 <div class="klaviyo-form-TA8JnT absolute inset-x-0 top-[52px]"></div>
 
                 <div class="mt-2">
-                  <input aria-hidden="true" id="collapsible" class="hidden peer" type="checkbox" />
+                  <input aria-hidden="true" id="FooterNewsletterTerms-{{ section.id }}" class="hidden peer" type="checkbox" />
                   <div class="overflow-hidden max-h-10 peer-checked:max-h-screen transition-max-height leading-6">
                     <small class="block text-xs leading-none mt-1 pb-1 a:link a:underline-offset-1">{{ section.settings.newsletter_terms }}</small>
                   </div>
-                  <label aria-hidden="true" for="collapsible" class="text-xs link mt-1 block peer-checked:hidden">Read more</label>
-                  <label aria-hidden="true" for="collapsible" class="text-xs link mt-1 hidden peer-checked:block">Read less</label>
+                  <label aria-hidden="true" for="FooterNewsletterTerms-{{ section.id }}" class="text-xs link mt-1 block peer-checked:hidden">Read more</label>
+                  <label aria-hidden="true" for="FooterNewsletterTerms-{{ section.id }}" class="text-xs link mt-1 hidden peer-checked:block">Read less</label>
                 </div>
               </div>
             </div>

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -284,7 +284,7 @@
                   endif
                 -%}
                 {%- if upsell_count > 1 -%}
-                  <input aria-hidden="true" id="collapsible" class="hidden peer" type="checkbox" />
+                  <input aria-hidden="true" id="ProductUpsellsCollapsible-{{ section.id }}-{{ block.id }}" class="hidden peer" type="checkbox" />
                 {%- endif -%}
                 <div class="{{ block.settings.upsell_classes }}{% if upsell_count > 1 %} max-h-[140px] overflow-hidden peer-checked:max-h-[1000px] motion-safe:transition-max-height{% endif %}" {{ block.shopify_attributes }}>
                   {%- if block.settings.upsell_enable_sets and product.metafields.my_fields.save_with_sets != nil -%}
@@ -313,8 +313,8 @@
                   {% endif %}
                 </div>
                 {%- if upsell_count > 1 -%}
-                  <label aria-hidden="true" for="collapsible" class="block col-span-12 mt-1 text-sm link peer-checked:hidden">View more {% render 'icon-arrow', variant: 'short', classes: 'rotate-90 w-4 h-4 inline-block ml-1' %}</label>
-                  <label aria-hidden="true" for="collapsible" class="hidden col-span-12 mt-1 text-sm link peer-checked:block">View less {% render 'icon-arrow', variant: 'short', classes: '-rotate-90 w-4 h-4 inline-block ml-1' %}</label>
+                  <label aria-hidden="true" for="ProductUpsellsCollapsible-{{ section.id }}-{{ block.id }}" class="block col-span-12 mt-1 text-sm link peer-checked:hidden">View more {% render 'icon-arrow', variant: 'short', classes: 'rotate-90 w-4 h-4 inline-block ml-1' %}</label>
+                  <label aria-hidden="true" for="ProductUpsellsCollapsible-{{ section.id }}-{{ block.id }}" class="hidden col-span-12 mt-1 text-sm link peer-checked:block">View less {% render 'icon-arrow', variant: 'short', classes: '-rotate-90 w-4 h-4 inline-block ml-1' %}</label>
                 {%- endif -%}
               {%- endif -%}
             {%- when 'set_includes' -%}

--- a/sections/product-clinicals.liquid
+++ b/sections/product-clinicals.liquid
@@ -27,13 +27,11 @@
             </ul>
             {%- if clinical_result.citations != blank -%}
               {%- assign citations_array = clinical_result.citations | split: '<br />' -%}
-              <cite class="block mt-4 lg:mt-6 text-xs pr-4 sm:pr-6">
-                <ul class="leading-tight">
-                  {%- for citation in citations_array -%}
-                    <li>{{ citation }}</li>
-                  {%- endfor -%}
-                </ul>
-              </cite>
+              <ul class="mt-4 lg:mt-6 text-xs pr-4 sm:pr-6 leading-tight">
+                {%- for citation in citations_array -%}
+                  <li><cite>{{ citation }}</cite></li>
+                {%- endfor -%}
+              </ul>
             {%- endif -%}
           </div>
         {%- endfor -%}


### PR DESCRIPTION
## What changed

- Give the footer newsletter disclosure checkbox a section-scoped ID and update its labels.
- Give product upsell disclosure checkboxes section/block-scoped IDs and update their labels.
- Restructure clinical citations so each `<cite>` is contained by a valid `<li>` inside the `<ul>`.

## Why

The previous shared `collapsible` ID produced duplicate IDs on product pages. The clinical citations also placed a `<ul>` directly inside `<cite>`, which is invalid HTML. Both were reported as P1 Standards findings by SortSite.

## Impact

This preserves the existing disclosure behavior and visual presentation while producing valid, uniquely associated markup. No JavaScript or third-party integration behavior was changed.

## Validation

- `npm run build`
- `shopify theme check` (passes with pre-existing warnings only)
- `git diff --check`
- Rendered DOM assertions for unique IDs, label associations, and citation structure
- Visual comparison of product upsells, clinical citations, and footer terms
- Targeted SortSite Current Page scan: duplicate ID finding reduced to 0; invalid list/citation finding reduced to 0