### PR TITLE
Add reusable image theme block

### DIFF
--- a/blocks/group.liquid
+++ b/blocks/group.liquid
@@ -1,0 +1,77 @@
+<div
+  class="theme-block-group theme-block-group--{{ block.settings.direction }}"
+  style="--theme-block-group-gap: {{ block.settings.gap }}px;"
+  {{ block.shopify_attributes }}
+>
+  {% content_for 'blocks' %}
+</div>
+
+{% stylesheet %}
+  .theme-block-group {
+    display: flex;
+    flex-direction: column;
+    gap: var(--theme-block-group-gap);
+    width: 100%;
+  }
+
+  .theme-block-group--horizontal {
+    flex-direction: row;
+  }
+
+  .theme-block-group--horizontal > * {
+    flex: 1 1 0;
+    min-width: 0;
+  }
+
+  @media (max-width: 39.999rem) {
+    .theme-block-group--horizontal {
+      flex-direction: column;
+    }
+  }
+{% endstylesheet %}
+
+{% schema %}
+{
+  "name": "Group",
+  "tag": null,
+  "blocks": [
+    {
+      "type": "@theme"
+    }
+  ],
+  "settings": [
+    {
+      "type": "select",
+      "id": "direction",
+      "label": "Direction",
+      "info": "Horizontal groups stack vertically on mobile.",
+      "options": [
+        {
+          "value": "vertical",
+          "label": "Vertical"
+        },
+        {
+          "value": "horizontal",
+          "label": "Horizontal"
+        }
+      ],
+      "default": "vertical"
+    },
+    {
+      "type": "range",
+      "id": "gap",
+      "label": "Gap",
+      "min": 0,
+      "max": 80,
+      "step": 4,
+      "unit": "px",
+      "default": 0
+    }
+  ],
+  "presets": [
+    {
+      "name": "Group"
+    }
+  ]
+}
+{% endschema %}

--- a/blocks/image.liquid
+++ b/blocks/image.liquid
@@ -68,7 +68,7 @@
 -%}
 
 <div
-  class="theme-image-block theme-image-block--{{ block.settings.alignment }} theme-image-block--ratio-{{ block.settings.aspect_ratio }}"
+  class="theme-image-block theme-image-block--{{ block.settings.alignment }} theme-image-block--width-{{ block.settings.width }} theme-image-block--ratio-{{ block.settings.aspect_ratio }}"
   style="
     --theme-image-aspect-ratio: {{ aspect_ratio }};
     --theme-image-custom-width: {{ block.settings.custom_width }}px;
@@ -81,7 +81,7 @@
   "
   {{ block.shopify_attributes }}
 >
-  <div class="theme-image-block__media theme-image-block__media--{{ block.settings.width }}">
+  <div class="theme-image-block__media">
     {%- if display_image != blank -%}
       {% render 'media-image',
         image: display_image,
@@ -104,39 +104,37 @@
 {% stylesheet %}
   .theme-image-block {
     display: flex;
+    max-width: 100%;
     width: 100%;
   }
 
   .theme-image-block--left {
-    justify-content: flex-start;
+    margin-right: auto;
   }
 
   .theme-image-block--center {
-    justify-content: center;
+    margin-left: auto;
+    margin-right: auto;
   }
 
   .theme-image-block--right {
-    justify-content: flex-end;
+    margin-left: auto;
   }
 
-  .theme-image-block__media {
-    max-width: 100%;
-  }
-
-  .theme-image-block__media--fill {
+  .theme-image-block--width-fill {
     width: 100%;
   }
 
-  .theme-image-block__media--fit {
+  .theme-image-block--width-fit {
     width: min(100%, var(--theme-image-natural-width));
   }
 
-  .theme-image-block__media--custom {
+  .theme-image-block--width-custom {
     width: min(100%, var(--theme-image-custom-width));
   }
 
-  .theme-image-block__media:not(.theme-image-block__media--fill) {
-    flex-shrink: 0;
+  .theme-image-block__media {
+    width: 100%;
   }
 
   .theme-image-block__media picture {

--- a/blocks/image.liquid
+++ b/blocks/image.liquid
@@ -1,0 +1,342 @@
+{%- liquid
+  assign image_desktop = block.settings.image
+  assign image_mobile = block.settings.image_mobile
+  assign display_image = image_desktop | default: image_mobile
+  assign display_image_mobile = image_mobile | default: image_desktop
+  assign display_image_desktop = image_desktop | default: image_mobile
+  assign natural_width = display_image.width | default: block.settings.custom_width
+  assign focal_point_mobile = display_image_mobile.presentation.focal_point | default: '50% 50%'
+  assign focal_point_desktop = display_image_desktop.presentation.focal_point | default: '50% 50%'
+
+  assign natural_aspect_ratio_mobile = 'auto'
+  if display_image_mobile != blank
+    capture natural_aspect_ratio_mobile
+      echo display_image_mobile.width
+      echo ' / '
+      echo display_image_mobile.height
+    endcapture
+  endif
+
+  assign natural_aspect_ratio_desktop = 'auto'
+  if display_image_desktop != blank
+    capture natural_aspect_ratio_desktop
+      echo display_image_desktop.width
+      echo ' / '
+      echo display_image_desktop.height
+    endcapture
+  endif
+
+  case block.settings.aspect_ratio
+    when 'square'
+      assign aspect_ratio = '1 / 1'
+    when 'portrait'
+      assign aspect_ratio = '4 / 5'
+    when 'landscape'
+      assign aspect_ratio = '16 / 9'
+    else
+      assign aspect_ratio = 'auto'
+  endcase
+
+  assign widths_preset = 'generic'
+  assign sizes = '100vw'
+  if block.settings.width == 'fill'
+    assign widths_preset = 'banner'
+  elsif block.settings.width == 'custom'
+    capture sizes
+      echo '(min-width: '
+      echo block.settings.custom_width
+      echo 'px) '
+      echo block.settings.custom_width
+      echo 'px, 100vw'
+    endcapture
+  elsif display_image != blank
+    capture sizes
+      echo '(min-width: '
+      echo display_image.width
+      echo 'px) '
+      echo display_image.width
+      echo 'px, 100vw'
+    endcapture
+  endif
+
+  assign loading = 'lazy'
+  assign fetchpriority = blank
+  if block.settings.prioritize_loading
+    assign loading = 'eager'
+    assign fetchpriority = 'high'
+  endif
+-%}
+
+<div
+  class="theme-image-block theme-image-block--{{ block.settings.alignment }} theme-image-block--ratio-{{ block.settings.aspect_ratio }}"
+  style="
+    --theme-image-aspect-ratio: {{ aspect_ratio }};
+    --theme-image-custom-width: {{ block.settings.custom_width }}px;
+    --theme-image-fit: {{ block.settings.image_fit }};
+    --theme-image-natural-width: {{ natural_width }}px;
+    --theme-image-natural-ratio-mobile: {{ natural_aspect_ratio_mobile }};
+    --theme-image-natural-ratio-desktop: {{ natural_aspect_ratio_desktop }};
+    --theme-image-position-mobile: {{ focal_point_mobile }};
+    --theme-image-position-desktop: {{ focal_point_desktop }};
+  "
+  {{ block.shopify_attributes }}
+>
+  <div class="theme-image-block__media theme-image-block__media--{{ block.settings.width }}">
+    {%- if display_image != blank -%}
+      {% render 'media-image',
+        image: display_image,
+        image_mobile: image_mobile,
+        image_desktop: image_desktop,
+        sizes: sizes,
+        widths_preset: widths_preset,
+        alt: block.settings.alt,
+        decorative: block.settings.decorative,
+        loading: loading,
+        fetchpriority: fetchpriority,
+        class: 'theme-image-block__image'
+      %}
+    {%- elsif request.design_mode -%}
+      {{ 'image' | placeholder_svg_tag: 'theme-image-block__placeholder' }}
+    {%- endif -%}
+  </div>
+</div>
+
+{% stylesheet %}
+  .theme-image-block {
+    display: flex;
+    width: 100%;
+  }
+
+  .theme-image-block--left {
+    justify-content: flex-start;
+  }
+
+  .theme-image-block--center {
+    justify-content: center;
+  }
+
+  .theme-image-block--right {
+    justify-content: flex-end;
+  }
+
+  .theme-image-block__media {
+    max-width: 100%;
+  }
+
+  .theme-image-block__media--fill {
+    width: 100%;
+  }
+
+  .theme-image-block__media--fit {
+    width: min(100%, var(--theme-image-natural-width));
+  }
+
+  .theme-image-block__media--custom {
+    width: min(100%, var(--theme-image-custom-width));
+  }
+
+  .theme-image-block__media:not(.theme-image-block__media--fill) {
+    flex-shrink: 0;
+  }
+
+  .theme-image-block__media picture {
+    display: block;
+    height: 100%;
+    width: 100%;
+  }
+
+  .theme-image-block__image,
+  .theme-image-block__placeholder {
+    display: block;
+    height: auto;
+    max-width: 100%;
+    width: 100%;
+  }
+
+  .theme-image-block__image {
+    object-fit: var(--theme-image-fit);
+    object-position: var(--theme-image-position-mobile);
+  }
+
+  .theme-image-block--ratio-adapt .theme-image-block__media {
+    aspect-ratio: var(--theme-image-natural-ratio-mobile);
+  }
+
+  .theme-image-block--ratio-adapt .theme-image-block__image {
+    height: 100%;
+  }
+
+  .theme-image-block--ratio-square .theme-image-block__media,
+  .theme-image-block--ratio-portrait .theme-image-block__media,
+  .theme-image-block--ratio-landscape .theme-image-block__media {
+    aspect-ratio: var(--theme-image-aspect-ratio);
+    overflow: hidden;
+  }
+
+  .theme-image-block--ratio-square .theme-image-block__image,
+  .theme-image-block--ratio-square .theme-image-block__placeholder,
+  .theme-image-block--ratio-portrait .theme-image-block__image,
+  .theme-image-block--ratio-portrait .theme-image-block__placeholder,
+  .theme-image-block--ratio-landscape .theme-image-block__image,
+  .theme-image-block--ratio-landscape .theme-image-block__placeholder {
+    height: 100%;
+  }
+
+  @media (min-width: 40rem) {
+    .theme-image-block--ratio-adapt .theme-image-block__media {
+      aspect-ratio: var(--theme-image-natural-ratio-desktop);
+    }
+
+    .theme-image-block__image {
+      object-position: var(--theme-image-position-desktop);
+    }
+  }
+{% endstylesheet %}
+
+{% schema %}
+{
+  "name": "Image",
+  "tag": null,
+  "settings": [
+    {
+      "type": "image_picker",
+      "id": "image",
+      "label": "Image"
+    },
+    {
+      "type": "image_picker",
+      "id": "image_mobile",
+      "label": "Mobile image",
+      "info": "Optional. Uses the main image when blank."
+    },
+    {
+      "type": "text",
+      "id": "alt",
+      "label": "Alt text override",
+      "info": "Leave blank to use the image's alt text.",
+      "visible_if": "{{ block.settings.decorative == false }}"
+    },
+    {
+      "type": "checkbox",
+      "id": "decorative",
+      "label": "Decorative image",
+      "info": "Enable only when the image adds no meaning. Hides it from screen readers.",
+      "default": false
+    },
+    {
+      "type": "header",
+      "content": "Layout"
+    },
+    {
+      "type": "select",
+      "id": "aspect_ratio",
+      "label": "Aspect ratio",
+      "options": [
+        {
+          "value": "adapt",
+          "label": "Original"
+        },
+        {
+          "value": "square",
+          "label": "Square"
+        },
+        {
+          "value": "portrait",
+          "label": "Portrait"
+        },
+        {
+          "value": "landscape",
+          "label": "Landscape"
+        }
+      ],
+      "default": "adapt"
+    },
+    {
+      "type": "select",
+      "id": "width",
+      "label": "Width",
+      "options": [
+        {
+          "value": "fill",
+          "label": "Fill available space"
+        },
+        {
+          "value": "fit",
+          "label": "Fit image"
+        },
+        {
+          "value": "custom",
+          "label": "Custom"
+        }
+      ],
+      "default": "fill"
+    },
+    {
+      "type": "range",
+      "id": "custom_width",
+      "label": "Custom maximum width",
+      "info": "Used when Width is set to Custom.",
+      "visible_if": "{{ block.settings.width == 'custom' }}",
+      "min": 100,
+      "max": 1600,
+      "step": 20,
+      "unit": "px",
+      "default": 800
+    },
+    {
+      "type": "select",
+      "id": "alignment",
+      "label": "Alignment",
+      "options": [
+        {
+          "value": "left",
+          "label": "Left"
+        },
+        {
+          "value": "center",
+          "label": "Center"
+        },
+        {
+          "value": "right",
+          "label": "Right"
+        }
+      ],
+      "default": "center",
+      "visible_if": "{{ block.settings.width != 'fill' }}"
+    },
+    {
+      "type": "select",
+      "id": "image_fit",
+      "label": "Image fit",
+      "options": [
+        {
+          "value": "cover",
+          "label": "Cover"
+        },
+        {
+          "value": "contain",
+          "label": "Contain"
+        }
+      ],
+      "default": "cover",
+      "visible_if": "{{ block.settings.aspect_ratio != 'adapt' }}"
+    },
+    {
+      "type": "header",
+      "content": "Performance"
+    },
+    {
+      "type": "checkbox",
+      "id": "prioritize_loading",
+      "label": "Prioritize image loading",
+      "info": "Enable only when this image is visible when the page first loads.",
+      "default": false
+    }
+  ],
+  "presets": [
+    {
+      "name": "Image"
+    }
+  ]
+}
+{% endschema %}

--- a/sections/theme-block-container.liquid
+++ b/sections/theme-block-container.liquid
@@ -1,0 +1,39 @@
+<div{% if section.settings.width == 'page' %} class="container"{% endif %}>
+  {% content_for 'blocks' %}
+</div>
+
+{% schema %}
+{
+  "name": "Theme block container",
+  "tag": "section",
+  "class": "section-theme-block-container",
+  "blocks": [
+    {
+      "type": "@theme"
+    }
+  ],
+  "settings": [
+    {
+      "type": "select",
+      "id": "width",
+      "label": "Container width",
+      "options": [
+        {
+          "value": "page",
+          "label": "Page width"
+        },
+        {
+          "value": "full",
+          "label": "Full width"
+        }
+      ],
+      "default": "page"
+    }
+  ],
+  "presets": [
+    {
+      "name": "Theme block container"
+    }
+  ]
+}
+{% endschema %}

--- a/snippets/media-image.liquid
+++ b/snippets/media-image.liquid
@@ -13,10 +13,15 @@
     sizes_mobile         — sizes string for mobile source (optional)
     sizes_desktop        — sizes string for desktop source (optional)
 
-    widths               — CSV list of widths to generate (e.g. "320,480,640,800")
-    widths_preset        — 'plp' | 'banner' | 'generic' (ignored if widths given)
+    widths               — ascending CSV list of widths (e.g. "320,480,640,800")
+    widths_mobile        — mobile CSV override for art-directed images (optional)
+    widths_desktop       — desktop CSV override for art-directed images (optional)
+    widths_preset        — 'banner' | 'half' | 'plp' | 'generic' (ignored if widths given)
+    fallback_width       — fallback src width for single-source images (optional)
+    fallback_width_mobile — fallback src width for art-directed images (optional)
 
     alt                  — override alt text (falls back to asset alt)
+    decorative           — true for intentionally decorative images (optional)
     loading              — 'lazy' | 'eager' (default 'lazy', forced to 'eager' when fetchpriority=='high')
     fetchpriority        — 'high' | 'low' | 'auto' (optional)
     decoding             — 'async' | 'auto' (default 'async')
@@ -27,9 +32,22 @@
     desktop_min          — breakpoint for desktop source (default '640px')
 
   Notes:
-    • Always runs through imgix via {% render 'imgix' %}; GIFs bypass imgix.
+    • Uses imgix only for matching configured Shopify CDN URLs; GIFs and unmatched URLs bypass it.
     • Uses width descriptors + sizes so DPR is automatic (no explicit 2x/3x).
-    • Keep your width ladders modest (≈8–12 candidates) to avoid HTML bloat.
+    • Candidate widths larger than the source image are not rendered.
+    • Keep custom width ladders ascending and modest (≈8–12 candidates).
+
+  Basic usage:
+    {% render 'media-image', image: section.settings.image, widths_preset: 'half', class: 'block w-full' %}
+
+  Mobile/desktop usage:
+    {% render 'media-image',
+      image_mobile: section.settings.image_mobile,
+      image_desktop: section.settings.image_desktop,
+      widths_preset: 'banner',
+      fetchpriority: 'high',
+      class: 'block w-full'
+    %}
 {% endcomment %}
 
 {%- liquid
@@ -38,61 +56,60 @@
     assign mode = 'art'
   endif
 
-  # Width ladder
-  if widths != blank
-    assign widths_list = widths
-  else
-    case widths_preset
-      when 'banner' 
-        # Full-bleed/hero across breakpoints (rem-aware)
-        assign widths_list = '800,1200,1600,2000,2400,2880'
-      when 'mobile-full-desktop-half'
-        # 100vw on mobile, ~50vw on desktop (>= lg)
-        assign widths_list = '400,640,800,960,1200,1440,1600'
-      when 'mobile-half-desktop-fifth'
-        # 50vw on mobile, ~20vw on desktop (>= lg)
-        assign widths_list = '175,208,232,288,328,400,464,576,720,960'
-      else          
-        # Generic ladder
-        assign widths_list = '320,480,640,800,1024,1280,1600,1920,2400'
-    endcase
-  endif
+  # Presets define both the width candidates and their matching sizes value.
+  case widths_preset
+    when 'banner'
+      assign preset_widths = '320,480,640,750,960,1200,1600,2000,2400,2880'
+      assign preset_widths_mobile = '320,480,640,750'
+      assign preset_widths_desktop = '640,800,960,1200,1600,2000,2400,2880'
+      assign preset_sizes = '100vw'
+      assign preset_sizes_mobile = '100vw'
+      assign preset_sizes_desktop = '100vw'
+      assign preset_fallback_width = 1200
+      assign preset_fallback_width_mobile = 480
+    when 'half', 'mobile-full-desktop-half'
+      assign preset_widths = '320,480,640,800,960,1200,1440,1600'
+      assign preset_widths_mobile = preset_widths
+      assign preset_widths_desktop = preset_widths
+      assign preset_sizes = '(min-width: 64rem) 50vw, 100vw'
+      assign preset_sizes_mobile = '100vw'
+      assign preset_sizes_desktop = '50vw'
+      assign preset_fallback_width = 960
+      assign preset_fallback_width_mobile = 480
+    when 'plp', 'mobile-half-desktop-fifth'
+      assign preset_widths = '175,208,232,288,328,400,464,576,720,960'
+      assign preset_widths_mobile = preset_widths
+      assign preset_widths_desktop = preset_widths
+      assign preset_sizes = '(min-width: 64rem) 20vw, 50vw'
+      assign preset_sizes_mobile = '50vw'
+      assign preset_sizes_desktop = '20vw'
+      assign preset_fallback_width = 576
+      assign preset_fallback_width_mobile = 328
+    else
+      assign preset_widths = '320,480,640,800,1024,1280,1600,1920,2400'
+      assign preset_widths_mobile = preset_widths
+      assign preset_widths_desktop = preset_widths
+      assign preset_sizes = '100vw'
+      assign preset_sizes_mobile = '100vw'
+      assign preset_sizes_desktop = '100vw'
+      assign preset_fallback_width = 800
+      assign preset_fallback_width_mobile = 480
+  endcase
+
+  assign widths_list = widths | default: preset_widths
+  assign widths_mobile_list = widths_mobile | default: widths | default: preset_widths_mobile
+  assign widths_desktop_list = widths_desktop | default: widths | default: preset_widths_desktop
   assign widths_arr = widths_list | split: ','
+  assign widths_mobile_arr = widths_mobile_list | split: ','
+  assign widths_desktop_arr = widths_desktop_list | split: ','
 
-  # Sizes
-  assign sizes_single  = sizes | default: '100vw'
-  assign sizes_mobile  = sizes_mobile | default: sizes | default: '100vw'
-  assign sizes_desktop = sizes_desktop | default: sizes | default: '100vw'
-  assign desktop_min   = desktop_min | default: '40rem'
-
-  # If sizes aren't provided, infer sensible defaults from widths_preset
-  if mode == 'single' and sizes == blank and widths_preset != blank
-    case widths_preset
-      when 'banner'
-        assign sizes_single = '100vw'
-      when 'mobile-full-desktop-half'
-        assign sizes_single = '(min-width: 64rem) 50vw, 100vw'
-      when 'mobile-half-desktop-fifth'
-        assign sizes_single = '(min-width: 64rem) 20vw, 50vw'
-    endcase
-  endif
-
-  # rem-based auto-sizes for art direction presets
-  if mode == 'art' and widths_preset != blank
-    if sizes_mobile == blank or sizes_desktop == blank
-      case widths_preset
-        when 'banner'
-          assign sizes_mobile  = '100vw'
-          assign sizes_desktop = '100vw'
-        when 'mobile-full-desktop-half'
-          assign sizes_mobile  = '100vw'
-          assign sizes_desktop = '50vw'
-        when 'mobile-half-desktop-fifth'
-          assign sizes_mobile  = '50vw'
-          assign sizes_desktop = '20vw'
-      endcase
-    endif
-  endif
+  assign sizes_single = sizes | default: preset_sizes
+  assign sizes_mobile = sizes_mobile | default: sizes | default: preset_sizes_mobile
+  assign sizes_desktop = sizes_desktop | default: sizes | default: preset_sizes_desktop
+  assign requested_fallback_width = fallback_width
+  assign fallback_width = fallback_width | default: preset_fallback_width
+  assign fallback_width_mobile = fallback_width_mobile | default: requested_fallback_width | default: preset_fallback_width_mobile
+  assign desktop_min = desktop_min | default: '40rem'
 
   # Fit classes
   assign fit_class = ''
@@ -103,67 +120,97 @@
   endif
 
   # Loading defaults
-  if loading == blank
-    if fetchpriority == 'high'
-      assign loading = 'eager'
-    else
-      assign loading = 'lazy'
-    endif
+  if fetchpriority == 'high'
+    assign loading = 'eager'
+  elsif loading == blank
+    assign loading = 'lazy'
   endif
+  unless loading == 'lazy' or loading == 'eager'
+    assign loading = 'lazy'
+  endunless
+
+  unless fetchpriority == blank or fetchpriority == 'high' or fetchpriority == 'low' or fetchpriority == 'auto'
+    assign fetchpriority = blank
+  endunless
+
   assign decoding = decoding | default: 'async'
+  unless decoding == 'async' or decoding == 'sync' or decoding == 'auto'
+    assign decoding = 'async'
+  endunless
 -%}
 
 {%- if mode == 'single' and image != blank -%}
   {%- liquid
     # Build srcset for single image
     assign srcset_parts = ''
+    assign last_candidate_width = 0
     for w in widths_arr
-      assign w = w | strip
-      if w == ''
+      assign candidate_width = w | strip | plus: 0
+      if candidate_width <= 0
         continue
       endif
-      assign raw_url = image | image_url: width: w
-      if image contains '.gif'
+
+      if candidate_width > image.width
+        assign candidate_width = image.width
+      endif
+      if candidate_width <= last_candidate_width
+        continue
+      endif
+
+      assign raw_url = image | image_url: width: candidate_width
+      if raw_url contains '.gif'
         assign optimized = raw_url
-      else
+      elsif settings.enableImgix and settings.shopifyCdnUrl != blank and settings.imgixUrl != blank and raw_url contains settings.shopifyCdnUrl
         capture optimized
-          render 'imgix', src: raw_url
+          render 'imgix', src: raw_url, w: candidate_width
         endcapture
+      else
+        assign optimized = raw_url
       endif
       if srcset_parts == ''
-        assign srcset_parts = optimized | append: ' ' | append: w | append: 'w'
+        assign srcset_parts = optimized | append: ' ' | append: candidate_width | append: 'w'
       else
-        assign srcset_parts = srcset_parts | append: '||' | append: optimized | append: ' ' | append: w | append: 'w'
+        assign srcset_parts = srcset_parts | append: '||' | append: optimized | append: ' ' | append: candidate_width | append: 'w'
+      endif
+      assign last_candidate_width = candidate_width
+      if candidate_width >= image.width
+        break
       endif
     endfor
     assign srcset_attr = srcset_parts | split: '||' | join: ', '
 
-    # Fallback src (use the smallest width provided)
-    assign first_w = widths_arr | first | strip
-    assign raw_src = image | image_url: width: first_w
-    if image contains '.gif'
+    # Use a useful fallback size without requesting pixels larger than the source.
+    assign fallback_src_width = fallback_width | plus: 0 | at_most: image.width
+    if fallback_src_width <= 0
+      assign fallback_src_width = image.width
+    endif
+    assign raw_src = image | image_url: width: fallback_src_width
+    if raw_src contains '.gif'
       assign src_attr = raw_src
-    else
+    elsif settings.enableImgix and settings.shopifyCdnUrl != blank and settings.imgixUrl != blank and raw_src contains settings.shopifyCdnUrl
       capture src_attr
-        render 'imgix', src: raw_src
+        render 'imgix', src: raw_src, w: fallback_src_width
       endcapture
+    else
+      assign src_attr = raw_src
     endif
 
     # Alt text
-    assign alt_text = alt
-    if alt_text == blank and image.alt
-      assign alt_text = image.alt | escape
-    endif
+    assign alt_text = blank
+    unless decorative
+      assign alt_text = alt | default: image.alt
+    endunless
   -%}
 
   {% comment %} theme-check-disable RemoteAsset {% endcomment %}
   <img
-    {% if id %}id="{{ id }}"{% endif %}
-    class="{{ class }} {{ fit_class }}"
-    srcset="{{ srcset_attr }}"
-    sizes="{{ sizes_single }}"
-    src="{{ src_attr }}"
-    {% if alt_text != blank %}alt="{{ alt_text }}"{% else %}alt="" aria-hidden="true"{% endif %}
+    {% if id %}id="{{ id | escape }}"{% endif %}
+    {% if class != blank or fit_class != blank %}class="{{ class | escape }}{% if fit_class != blank %} {{ fit_class }}{% endif %}"{% endif %}
+    srcset="{{ srcset_attr | escape }}"
+    sizes="{{ sizes_single | escape }}"
+    src="{{ src_attr | escape }}"
+    alt="{{ alt_text | escape }}"
+    {% if decorative %}aria-hidden="true"{% endif %}
     loading="{{ loading }}"
     {% if fetchpriority %}fetchpriority="{{ fetchpriority }}"{% endif %}
     decoding="{{ decoding }}"
@@ -176,80 +223,113 @@
   {%- liquid
     # Build srcset for MOBILE
     assign m_parts = ''
-    for w in widths_arr
-      assign w = w | strip
-      if w == ''
+    assign last_mobile_candidate_width = 0
+    for w in widths_mobile_arr
+      assign candidate_width = w | strip | plus: 0
+      if candidate_width <= 0
         continue
       endif
-      assign m_raw = image_mobile | image_url: width: w
-      if image_mobile contains '.gif'
+
+      if candidate_width > image_mobile.width
+        assign candidate_width = image_mobile.width
+      endif
+      if candidate_width <= last_mobile_candidate_width
+        continue
+      endif
+
+      assign m_raw = image_mobile | image_url: width: candidate_width
+      if m_raw contains '.gif'
         assign m_opt = m_raw
-      else
+      elsif settings.enableImgix and settings.shopifyCdnUrl != blank and settings.imgixUrl != blank and m_raw contains settings.shopifyCdnUrl
         capture m_opt
-          render 'imgix', src: m_raw
+          render 'imgix', src: m_raw, w: candidate_width
         endcapture
+      else
+        assign m_opt = m_raw
       endif
       if m_parts == ''
-        assign m_parts = m_opt | append: ' ' | append: w | append: 'w'
+        assign m_parts = m_opt | append: ' ' | append: candidate_width | append: 'w'
       else
-        assign m_parts = m_parts | append: '||' | append: m_opt | append: ' ' | append: w | append: 'w'
+        assign m_parts = m_parts | append: '||' | append: m_opt | append: ' ' | append: candidate_width | append: 'w'
+      endif
+      assign last_mobile_candidate_width = candidate_width
+      if candidate_width >= image_mobile.width
+        break
       endif
     endfor
     assign m_srcset = m_parts | split: '||' | join: ', '
-    assign m_first_w = widths_arr | first | strip
-    assign m_raw_src = image_mobile | image_url: width: m_first_w
-    if image_mobile contains '.gif'
+    assign mobile_fallback_src_width = fallback_width_mobile | plus: 0 | at_most: image_mobile.width
+    if mobile_fallback_src_width <= 0
+      assign mobile_fallback_src_width = image_mobile.width
+    endif
+    assign m_raw_src = image_mobile | image_url: width: mobile_fallback_src_width
+    if m_raw_src contains '.gif'
       assign m_src = m_raw_src
-    else
+    elsif settings.enableImgix and settings.shopifyCdnUrl != blank and settings.imgixUrl != blank and m_raw_src contains settings.shopifyCdnUrl
       capture m_src
-        render 'imgix', src: m_raw_src
+        render 'imgix', src: m_raw_src, w: mobile_fallback_src_width
       endcapture
+    else
+      assign m_src = m_raw_src
     endif
 
     # Build srcset for DESKTOP
     assign d_parts = ''
-    for w in widths_arr
-      assign w = w | strip
-      if w == ''
+    assign last_desktop_candidate_width = 0
+    for w in widths_desktop_arr
+      assign candidate_width = w | strip | plus: 0
+      if candidate_width <= 0
         continue
       endif
-      assign d_raw = image_desktop | image_url: width: w
-      if image_desktop contains '.gif'
+
+      if candidate_width > image_desktop.width
+        assign candidate_width = image_desktop.width
+      endif
+      if candidate_width <= last_desktop_candidate_width
+        continue
+      endif
+
+      assign d_raw = image_desktop | image_url: width: candidate_width
+      if d_raw contains '.gif'
         assign d_opt = d_raw
-      else
+      elsif settings.enableImgix and settings.shopifyCdnUrl != blank and settings.imgixUrl != blank and d_raw contains settings.shopifyCdnUrl
         capture d_opt
-          render 'imgix', src: d_raw
+          render 'imgix', src: d_raw, w: candidate_width
         endcapture
+      else
+        assign d_opt = d_raw
       endif
       if d_parts == ''
-        assign d_parts = d_opt | append: ' ' | append: w | append: 'w'
+        assign d_parts = d_opt | append: ' ' | append: candidate_width | append: 'w'
       else
-        assign d_parts = d_parts | append: '||' | append: d_opt | append: ' ' | append: w | append: 'w'
+        assign d_parts = d_parts | append: '||' | append: d_opt | append: ' ' | append: candidate_width | append: 'w'
+      endif
+      assign last_desktop_candidate_width = candidate_width
+      if candidate_width >= image_desktop.width
+        break
       endif
     endfor
     assign d_srcset = d_parts | split: '||' | join: ', '
 
     # Alt text preference: explicit alt > mobile alt > desktop alt
-    assign alt_text = alt
-    if alt_text == blank and image_mobile.alt
-      assign alt_text = image_mobile.alt | escape
-    endif
-    if alt_text == blank and image_desktop.alt
-      assign alt_text = image_desktop.alt | escape
-    endif
+    assign alt_text = blank
+    unless decorative
+      assign alt_text = alt | default: image_mobile.alt | default: image_desktop.alt
+    endunless
   -%}
 
   {% comment %} theme-check-disable ImgLazyLoading, RemoteAsset {% endcomment %}
   <picture>
-    <source srcset="{{ d_srcset }}" sizes="{{ sizes_desktop }}" media="(min-width: {{ desktop_min }})">
-    <source srcset="{{ m_srcset }}" sizes="{{ sizes_mobile }}" media="(max-width: calc({{ desktop_min }} - 1px))">
+    <source srcset="{{ d_srcset | escape }}" sizes="{{ sizes_desktop | escape }}" media="(min-width: {{ desktop_min | escape }})">
+    <source srcset="{{ m_srcset | escape }}" sizes="{{ sizes_mobile | escape }}" media="(max-width: calc({{ desktop_min | escape }} - 1px))">
     <img
-      {% if id %}id="{{ id }}"{% endif %}
-      class="{{ class }} {{ fit_class }}"
-      srcset="{{ m_srcset }}"
-      sizes="{{ sizes_mobile }}"
-      src="{{ m_src }}"
-      {% if alt_text != blank %}alt="{{ alt_text }}"{% else %}alt="" aria-hidden="true"{% endif %}
+      {% if id %}id="{{ id | escape }}"{% endif %}
+      {% if class != blank or fit_class != blank %}class="{{ class | escape }}{% if fit_class != blank %} {{ fit_class }}{% endif %}"{% endif %}
+      srcset="{{ m_srcset | escape }}"
+      sizes="{{ sizes_mobile | escape }}"
+      src="{{ m_src | escape }}"
+      alt="{{ alt_text | escape }}"
+      {% if decorative %}aria-hidden="true"{% endif %}
       loading="{{ loading }}"
       {% if fetchpriority %}fetchpriority="{{ fetchpriority }}"{% endif %}
       decoding="{{ decoding }}"


### PR DESCRIPTION
## What changed

- Added a reusable Image theme block with desktop/mobile images, layout, accessibility, and loading controls.
- Added a nestable Group block with direction and gap controls, including mobile stacking.
- Added a minimal Theme block container section.
- Improved responsive image output and safe Imgix/GIF handling in `media-image`.

## Why

This is the first component for the Shopify Blocks Everywhere project and establishes the nested theme-block structure for the remaining components.

## Impact

Merchants can compose responsive Image blocks inside Groups without JavaScript. Existing templates and storefront content are unchanged.

## Validation

- `shopify theme check` — passed with pre-existing repository warnings only
- `git diff --check` — passed
- Desktop and mobile preview checks — passed
- Responsive image URLs checked for empty or duplicated values