### PR TITLE
Hide product details link for lip oil keychain

### DIFF
--- a/sections/product-set-includes.liquid
+++ b/sections/product-set-includes.liquid
@@ -57,10 +57,14 @@
                     </div>
                   {%- endif -%}
 
-                  <a class="link text-sm font-book" href="{{ product_url }}">
-                    <span>View full product details</span>
-                    {% render 'icon-arrow', variant: 'short', classes: 'w-4 h-4 inline-block ml-0.5', stroke_width: 2 %}
-                  </a>
+                  {%- unless product_in_set.id == 8683931631799
+                    or product_in_set.handle == '30th-anniversary-lip-oil-keychain'
+                  -%}
+                    <a class="link text-sm font-book" href="{{ product_url }}">
+                      <span>View full product details</span>
+                      {% render 'icon-arrow', variant: 'short', classes: 'w-4 h-4 inline-block ml-0.5', stroke_width: 2 %}
+                    </a>
+                  {%- endunless -%}
                 </div>
 
                 {%- liquid


### PR DESCRIPTION
## Summary

- Hide the “View full product details” link for the 30th Anniversary Lip Oil Keychain.
- Match the product by Shopify product ID or handle so the exclusion remains narrowly scoped.

## Why

The product-set section always rendered the details link, but this promotional product should not expose that navigation option.

## Impact

All other products continue to render the details link unchanged. Only product ID `8683931631799` or handle `30th-anniversary-lip-oil-keychain` is excluded.

## Validation

- `shopify theme check` (passed with existing warnings only)
- `git diff --check`