### PR TITLE
Hide lip oil keychain product card

### DIFF
--- a/snippets/product-in-set.liquid
+++ b/snippets/product-in-set.liquid
@@ -18,6 +18,7 @@
     assign short_description = product.metafields.custom_fields.short_description
   endif
 -%}
+{%- unless product.id == 8683931631799 or product.handle == '30th-anniversary-lip-oil-keychain' -%}
 <div class="relative bg-white items-center mb-4 last:mb-0 border border-seaweed-300 rounded-lg {{ classes }}">
   <div class="flex flex-row gap-4 items-center">
     <div class="w-full order-1 grow flex flex-col items-start py-2">
@@ -61,3 +62,4 @@
     {%- endif -%}
   </div>
 </div>
+{%- endunless -%}


### PR DESCRIPTION
## Summary

- Suppress the complete `product-in-set` card for the 30th Anniversary Lip Oil Keychain.
- Match by Shopify product ID or handle to keep the exclusion narrowly scoped.

## Why

The product should not appear as a product card in contexts that render the `product-in-set` snippet.

## Impact

Only product ID `8683931631799` or handle `30th-anniversary-lip-oil-keychain` is excluded. All other product cards render unchanged.

## Validation

- `shopify theme check` (passed with existing warnings only)
- `git diff --check`