### PR TITLE
Disable keychain product page links

### DIFF
--- a/sections/product-set-includes.liquid
+++ b/sections/product-set-includes.liquid
@@ -6,6 +6,11 @@
         <ul class="scroll-box flex gap-2 sm:gap-4 lg:gap-6 snap-x snap-mandatory overflow-x-auto">
           {%- for product_in_set in product.metafields.custom.set_contains.value -%}
             {%- liquid
+              assign disable_product_links = false
+              if product_in_set.id == 8683931631799 or product_in_set.handle == '30th-anniversary-lip-oil-keychain'
+                assign disable_product_links = true
+              endif
+
               if product_in_set.metafields.custom.parent_product != blank
                 assign product_url = product_in_set.metafields.custom.parent_product.value.url
                 assign description = product_in_set.metafields.custom.parent_product.value.metafields.custom_fields.description
@@ -26,11 +31,19 @@
             <li class="snap-start flex-1 rounded-lg bg-p-surface p-4 lg:p-6 xl:p-8 min-w-[288px] xs:min-w-[320px] sm:min-w-[480px] md:min-w-[620px]" style="--p-surface: {{ product_in_set.metafields.theme.surface | default: '#f1f5f4' }}">
               <div class="flex flex-col md:flex-row gap-4 mb-4">
                 <div class="w-full order-1 grow flex flex-col items-start">
-                  <a href="{{ product_url | default: '#' }}" class="block no-underline">
+                  {%- if disable_product_links -%}
+                    <div class="block">
+                  {%- else -%}
+                    <a href="{{ product_url | default: '#' }}" class="block no-underline">
+                  {%- endif -%}
                     <h4 class="text-lg leading-tight font-bold">
                       {{ product_in_set.title | replace: 'Deluxe Sample ', '' | escape }}
                     </h4>
-                  </a>
+                  {%- if disable_product_links -%}
+                    </div>
+                  {%- else -%}
+                    </a>
+                  {%- endif -%}
                   <p class="text-sm">{{ short_description }}</p>
                   <p class="text-sm mb-3">{{ product_in_set.metafields.my_fields.size }}</p>
 
@@ -57,9 +70,7 @@
                     </div>
                   {%- endif -%}
 
-                  {%- unless product_in_set.id == 8683931631799
-                    or product_in_set.handle == '30th-anniversary-lip-oil-keychain'
-                  -%}
+                  {%- unless disable_product_links -%}
                     <a class="link text-sm font-book" href="{{ product_url }}">
                       <span>View full product details</span>
                       {% render 'icon-arrow', variant: 'short', classes: 'w-4 h-4 inline-block ml-0.5', stroke_width: 2 %}
@@ -90,12 +101,16 @@
                 -%}
 
                 {%- if image_object -%}
-                  <a
-                    aria-label="{{ product_in_set.title | escape }}"
-                    href="{{ product_url | default: '#' }}"
-                    class="group relative block mx-auto no-underline shrink-0 max-w-full w-72 h-84 bg-wave-100 rounded-l-lg"
-                    tabindex="-1"
-                  >
+                  {%- if disable_product_links -%}
+                    <div class="relative block mx-auto shrink-0 max-w-full w-72 h-84 bg-wave-100 rounded-l-lg">
+                  {%- else -%}
+                    <a
+                      aria-label="{{ product_in_set.title | escape }}"
+                      href="{{ product_url | default: '#' }}"
+                      class="group relative block mx-auto no-underline shrink-0 max-w-full w-72 h-84 bg-wave-100 rounded-l-lg"
+                      tabindex="-1"
+                    >
+                  {%- endif -%}
                     {% comment %} theme-check-disable RemoteAsset {% endcomment %}
                     <img
                       src="{% render 'imgix', src: main_master, w: 800 %}"
@@ -113,7 +128,11 @@
                       class="w-full h-full object-cover rounded-lg"
                     >
                     {% comment %} theme-check-enable RemoteAsset {% endcomment %}
-                  </a>
+                  {%- if disable_product_links -%}
+                    </div>
+                  {%- else -%}
+                    </a>
+                  {%- endif -%}
                 {%- endif -%}
               </div>
 

--- a/snippets/product-in-set.liquid
+++ b/snippets/product-in-set.liquid
@@ -10,6 +10,11 @@
 {% endcomment %}
 
 {%- liquid
+  assign disable_product_links = false
+  if product.id == 8683931631799 or product.handle == '30th-anniversary-lip-oil-keychain'
+    assign disable_product_links = true
+  endif
+
   if product.metafields.custom.parent_product != blank
     assign product_url = product.metafields.custom.parent_product.value.url
     assign short_description = product.metafields.custom.parent_product.value.metafields.custom_fields.short_description
@@ -18,17 +23,24 @@
     assign short_description = product.metafields.custom_fields.short_description
   endif
 -%}
-{%- unless product.id == 8683931631799 or product.handle == '30th-anniversary-lip-oil-keychain' -%}
 <div class="relative bg-white items-center mb-4 last:mb-0 border border-seaweed-300 rounded-lg {{ classes }}">
   <div class="flex flex-row gap-4 items-center">
     <div class="w-full order-1 grow flex flex-col items-start py-2">
-      <a href="{{ product_url | default: '#' }}" class="group text-sm tracking-wide leading-tight no-underline">
+      {%- if disable_product_links -%}
+        <div class="text-sm tracking-wide leading-tight">
+      {%- else -%}
+        <a href="{{ product_url | default: '#' }}" class="group text-sm tracking-wide leading-tight no-underline">
+      {%- endif -%}
         <h4 class="font-medium group-hover:underline mb-0.5">
           {{ product.title | replace: 'Deluxe Sample ', '' | escape }}
         </h4>
         <p class="group-hover:underline mb-0.5">{{ short_description }}</p>
         <p class="group-hover:underline mb-1">{{ product.metafields.my_fields.size }}</p>
-      </a>
+      {%- if disable_product_links -%}
+        </div>
+      {%- else -%}
+        </a>
+      {%- endif -%}
     </div>
 
     {%- liquid
@@ -41,12 +53,16 @@
       assign main_image_src_2x = image_object | image_url: width: 160, height: 160, crop: 'center'
     -%}
     {%- if image_object -%}
-      <a
-        aria-label="{{ product.title | escape }}"
-        href="{{ product_url | default: '#' }}"
-        class="group relative block mx-auto no-underline shrink-0 w-24 bg-wave-100 rounded-l-lg"
-        tabindex="-1"
-      >
+      {%- if disable_product_links -%}
+        <div class="relative block mx-auto shrink-0 w-24 bg-wave-100 rounded-l-lg">
+      {%- else -%}
+        <a
+          aria-label="{{ product.title | escape }}"
+          href="{{ product_url | default: '#' }}"
+          class="group relative block mx-auto no-underline shrink-0 w-24 bg-wave-100 rounded-l-lg"
+          tabindex="-1"
+        >
+      {%- endif -%}
         {% comment %} theme-check-disable RemoteAsset {% endcomment %}
         <img
           srcset="{% render 'imgix', src: main_image_src %} 1x, {% render 'imgix', src: main_image_src_2x %} 2x"
@@ -58,8 +74,11 @@
           class="mx-auto"
         >
         {% comment %} theme-check-enable RemoteAsset {% endcomment %}
-      </a>
+      {%- if disable_product_links -%}
+        </div>
+      {%- else -%}
+        </a>
+      {%- endif -%}
     {%- endif -%}
   </div>
 </div>
-{%- endunless -%}


### PR DESCRIPTION
## Summary

- Keep the 30th Anniversary Lip Oil Keychain visible in product-set cards.
- Render its title and image with non-interactive wrappers instead of links.
- Continue hiding the “View full product details” link in the Set Includes section.
- Apply the behavior in both `product-in-set` and `product-set-includes`.

## Why

The keychain should remain visible as part of a set, but customers should not be directed to its standalone product page. This replaces the previous behavior from #144, which hid the entire product card.

## Impact

Only product ID `8683931631799` or handle `30th-anniversary-lip-oil-keychain` is affected. Other products retain their existing title, image, and details links.

## Validation

- `shopify theme check` (passed with existing warnings only)
- `git diff --check`