### PR TITLE
Add paid-traffic review gating to product grid

### DIFF
--- a/sections/product-grid.liquid
+++ b/sections/product-grid.liquid
@@ -1,3 +1,9 @@
+{%- liquid
+  assign reviews_paid_only = false
+  if section.settings.show_reviews and section.settings.review_traffic == 'paid'
+    assign reviews_paid_only = true
+  endif
+-%}
 <div class="{{ section.settings.section_classes }}">
   <div class="{{ section.settings.container_classes }}">
     {%- for product in section.settings.collection.products -%}
@@ -10,7 +16,9 @@
         variant_picker_type: section.settings.variant_picker_type,
         variant_picker_classes: section.settings.variant_picker_classes,
         is_pdp_link: section.settings.is_pdp_link,
-        pdp_link_label: section.settings.pdp_link_label
+        pdp_link_label: section.settings.pdp_link_label,
+        show_reviews: section.settings.show_reviews,
+        reviews_paid_only: reviews_paid_only
       %}
     {%- endfor -%}
   </div>
@@ -43,6 +51,35 @@
       "id": "is_subscription",
       "label": "Subscription card",
       "default": false
+    },
+    {
+      "type": "header",
+      "content": "Reviews"
+    },
+    {
+      "type": "checkbox",
+      "id": "show_reviews",
+      "label": "Show product reviews",
+      "info": "Show star rating and review count on each card.",
+      "default": false
+    },
+    {
+      "type": "select",
+      "id": "review_traffic",
+      "label": "Show reviews to",
+      "info": "\"Paid traffic only\" gates reviews behind the paid-only component — visible only to visitors from paid campaigns.",
+      "default": "all",
+      "visible_if": "{{ section.settings.show_reviews }}",
+      "options": [
+        {
+          "value": "all",
+          "label": "All traffic"
+        },
+        {
+          "value": "paid",
+          "label": "Paid traffic only"
+        }
+      ]
     },
     {
       "type": "textarea",

--- a/snippets/card-product.liquid
+++ b/snippets/card-product.liquid
@@ -17,6 +17,7 @@
     - badge_class: {String} Tailwind styling classes (optional)
     - hide_badge: {Boolean} Hide text badge. Default: false (optional)
     - show_reviews: {Boolean} Show star review and review count. Default: false (optional)
+    - reviews_paid_only: {Boolean} Gate reviews to paid traffic via <paid-only>. Default: false (optional)
     - align_reviews_right: {Boolean} Align reviews to the right. Default: false (optional)
     - subscription: {Boolean} Default to subscription selection instead of variants (optional)
     - default_to_mini: {Boolean} Default variant selection to travel-sized (optional)
@@ -67,11 +68,13 @@
       endif
     -%}
     <div class="{{ title_wrapper_classes }}">
-      {% comment %} {%- if show_reviews -%} {% endcomment %}
-      {%- unless mini -%}
-        {% render 'product-rating', product: card_product, compact: compact_ratings, classes: ratings_classes %}
-      {%- endunless -%}
-      {% comment %} {%- endif -%} {% endcomment %}
+      {%- if show_reviews -%}
+        {%- unless mini -%}
+          {%- if reviews_paid_only -%}<paid-only class="block">{%- endif -%}
+          {% render 'product-rating', product: card_product, compact: compact_ratings, classes: ratings_classes %}
+          {%- if reviews_paid_only -%}</paid-only>{%- endif -%}
+        {%- endunless -%}
+      {%- endif -%}
       {%- liquid
         assign title_content = title_text | default: card_product.title
         assign title_accessible_text = title_content | strip_html


### PR DESCRIPTION
Add a 'Show product reviews' toggle to the product-grid section (which previously never passed show_reviews to card-product) plus a 'Show reviews to' dropdown offering all traffic or paid-only. When set to paid, each card's rating is wrapped in <paid-only> so reviews are revealed only to visitors from paid campaigns.