### PR TITLE
Add reusable Heading theme block

### DIFF
--- a/blocks/heading.liquid
+++ b/blocks/heading.liquid
@@ -1,0 +1,256 @@
+{%- liquid
+  assign block_settings = block.settings
+
+  case block_settings.font_family
+    when 'sans'
+      assign font_family_class = 'font-sans'
+    when 'serif'
+      assign font_family_class = 'font-serif'
+    else
+      assign font_family_class = ''
+  endcase
+
+  case block_settings.font_weight
+    when 'light'
+      assign font_weight_class = 'font-light'
+    when 'regular'
+      assign font_weight_class = 'font-regular'
+    when 'book'
+      assign font_weight_class = 'font-book'
+    when 'medium'
+      assign font_weight_class = 'font-medium'
+    when 'bold'
+      assign font_weight_class = 'font-bold'
+    else
+      assign font_weight_class = ''
+  endcase
+
+  case block_settings.alignment
+    when 'center'
+      assign alignment_class = 'text-center'
+    when 'right'
+      assign alignment_class = 'text-right'
+    else
+      assign alignment_class = 'text-left'
+  endcase
+
+  case block_settings.visibility
+    when 'mobile_only'
+      assign visibility_class = 'sm:hidden'
+    when 'desktop_only'
+      assign visibility_class = 'hidden sm:block'
+    else
+      assign visibility_class = ''
+  endcase
+-%}
+
+{%- if block_settings.enable_heading_size -%}
+  {% style %}
+    #Heading-{{ block.id }} {
+      font-size: {{ block_settings.heading_size_mobile }}px;
+    }
+
+    @media (min-width: 40rem) {
+      #Heading-{{ block.id }} {
+        font-size: {{ block_settings.heading_size_desktop }}px;
+      }
+    }
+  {% endstyle %}
+{%- endif -%}
+
+<{{ block_settings.heading_level }}
+  id="Heading-{{ block.id }}"
+  class="a:link {{ alignment_class }}{% if font_family_class != blank %} {{ font_family_class }}{% endif %}{% if font_weight_class != blank %} {{ font_weight_class }}{% endif %}{% if visibility_class != blank %} {{ visibility_class }}{% endif %}{% if block_settings.classnames != blank %} {{ block_settings.classnames | escape }}{% endif %}"
+  {% if block_settings.color != blank %}
+    style="color: {{ block_settings.color }};"
+  {% endif %}
+  {{ block.shopify_attributes }}
+>
+  {{- block_settings.heading -}}
+</{{ block_settings.heading_level }}>
+
+{% schema %}
+{
+  "name": "Heading",
+  "tag": null,
+  "settings": [
+    {
+      "type": "inline_richtext",
+      "id": "heading",
+      "label": "Heading",
+      "default": "Add a heading"
+    },
+    {
+      "type": "select",
+      "id": "heading_level",
+      "label": "Heading level",
+      "info": "Choose the level based on the page structure, not the visual size.",
+      "options": [
+        {
+          "value": "h1",
+          "label": "H1"
+        },
+        {
+          "value": "h2",
+          "label": "H2"
+        },
+        {
+          "value": "h3",
+          "label": "H3"
+        },
+        {
+          "value": "h4",
+          "label": "H4"
+        },
+        {
+          "value": "h5",
+          "label": "H5"
+        },
+        {
+          "value": "h6",
+          "label": "H6"
+        }
+      ],
+      "default": "h2"
+    },
+    {
+      "type": "color",
+      "id": "color",
+      "label": "Text color"
+    },
+    {
+      "type": "header",
+      "content": "Typography"
+    },
+    {
+      "type": "select",
+      "id": "font_family",
+      "label": "Font family",
+      "options": [
+        {
+          "value": "inherit",
+          "label": "Inherit"
+        },
+        {
+          "value": "sans",
+          "label": "Sans (Circular)"
+        },
+        {
+          "value": "serif",
+          "label": "Serif (Canela)"
+        }
+      ],
+      "default": "inherit"
+    },
+    {
+      "type": "select",
+      "id": "font_weight",
+      "label": "Font weight",
+      "options": [
+        {
+          "value": "inherit",
+          "label": "Inherit"
+        },
+        {
+          "value": "light",
+          "label": "Light"
+        },
+        {
+          "value": "regular",
+          "label": "Regular"
+        },
+        {
+          "value": "book",
+          "label": "Book"
+        },
+        {
+          "value": "medium",
+          "label": "Medium"
+        },
+        {
+          "value": "bold",
+          "label": "Bold"
+        }
+      ],
+      "default": "inherit"
+    },
+    {
+      "type": "checkbox",
+      "id": "enable_heading_size",
+      "label": "Enable heading size",
+      "info": "When disabled, heading size is inherited or controlled through classnames.",
+      "default": false
+    },
+    {
+      "type": "range",
+      "id": "heading_size_mobile",
+      "min": 12,
+      "max": 96,
+      "step": 1,
+      "unit": "px",
+      "label": "Mobile heading size",
+      "default": 32
+    },
+    {
+      "type": "range",
+      "id": "heading_size_desktop",
+      "min": 12,
+      "max": 96,
+      "step": 1,
+      "unit": "px",
+      "label": "Desktop heading size",
+      "default": 48
+    },
+    {
+      "type": "header",
+      "content": "Alignment"
+    },
+    {
+      "type": "text_alignment",
+      "id": "alignment",
+      "label": "Alignment",
+      "default": "left"
+    },
+    {
+      "type": "header",
+      "content": "Visibility"
+    },
+    {
+      "type": "select",
+      "id": "visibility",
+      "label": "Visibility",
+      "options": [
+        {
+          "value": "all",
+          "label": "Show everywhere"
+        },
+        {
+          "value": "mobile_only",
+          "label": "Mobile only"
+        },
+        {
+          "value": "desktop_only",
+          "label": "Desktop only"
+        }
+      ],
+      "default": "all"
+    },
+    {
+      "type": "header",
+      "content": "Advanced"
+    },
+    {
+      "type": "textarea",
+      "id": "classnames",
+      "label": "Classnames",
+      "info": "Optional Tailwind classes for developer styling."
+    }
+  ],
+  "presets": [
+    {
+      "name": "Heading",
+      "category": "Text"
+    }
+  ]
+}
+{% endschema %}


### PR DESCRIPTION
## Summary

- Add a reusable Heading theme block with independent H1-H6 semantics.
- Add merchant controls for text color, font family, font weight, alignment, and visibility.
- Add optional mobile and desktop pixel-size sliders behind an **Enable heading size** checkbox.
- Add an empty `classnames` textarea for advanced Tailwind styling.

## Behavior

Heading level and visual size are deliberately separate. For example, an H2 can be displayed at 48px without changing it to an H1 solely for appearance.

Font family and weight default to **Inherit**, so developer-provided classes remain in control unless a merchant selects a basic option. When the size checkbox is disabled, the block emits no font-size CSS.

Visibility provides **Show everywhere**, **Mobile only**, and **Desktop only**. Placement and width remain the responsibility of Container, Flex, and Grid.

## Integration

Depends on #140 for the Theme Block Container used to insert and compose reusable theme blocks. This branch remains based on `main` and contains only `blocks/heading.liquid`.

## Validation

- `npm run build`
- `shopify theme check` (passes with the repository's existing 54 warnings)
- `git diff --check`
- Theme Editor preview with the temporary #140 integration